### PR TITLE
fix: rule bugfixes

### DIFF
--- a/javascript/aws_lambda/sql_injection.yml
+++ b/javascript/aws_lambda/sql_injection.yml
@@ -69,7 +69,7 @@ auxiliary:
       - pattern: $<MYSQL_POOL>.getConnection(function($<_>, $<!>$<_>) {})
         filters:
           - variable: MYSQL_POOL
-            detection: javascript_express_sql_injection_mysql_pool
+            detection: javascript_aws_lambda_sql_injection_mysql_pool
 languages:
   - javascript
 severity: high

--- a/javascript/aws_lambda/sql_injection/.snapshots/mysql2_sql_injection.yml
+++ b/javascript/aws_lambda/sql_injection/.snapshots/mysql2_sql_injection.yml
@@ -1,2 +1,172 @@
-{}
+high:
+    - rule:
+        cwe_ids:
+            - "89"
+        id: javascript_aws_lambda_sql_injection
+        title: SQL injection vulnerability detected.
+        description: |
+            ## Description
+            Including unsanitized data, such as user input or request data, in raw SQL queries makes your application vulnerable to SQL injection attacks.
+
+
+            ## Remediations
+
+            Use safe sql libraries methods which sanitze user input
+
+            Sequelize example
+            ```javascript
+              const { Op } = require("sequelize");
+
+              module.exports= async function(event, context) {
+                await Post.findAll({
+                  where: {
+                    [Op.or]: [
+                      { authorId: event.authorID },
+                      { authorId: 13 }
+                    ]
+                  }
+                });
+              };
+            ```
+
+            ## Resources
+            - [OWASP sql injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_aws_lambda_sql_injection
+      line_number: 5
+      filename: /tmp/scan/mysql2_sql_injection.js
+      category_groups:
+        - PII
+        - Personal Data
+      parent_line_number: 5
+      snippet: connection.query("SELECT * FROM `user` WHERE name = " + event.customer.name)
+      fingerprint: 84ad7a8d4f19c9d729235bd7e1fcfe64_0
+    - rule:
+        cwe_ids:
+            - "89"
+        id: javascript_aws_lambda_sql_injection
+        title: SQL injection vulnerability detected.
+        description: |
+            ## Description
+            Including unsanitized data, such as user input or request data, in raw SQL queries makes your application vulnerable to SQL injection attacks.
+
+
+            ## Remediations
+
+            Use safe sql libraries methods which sanitze user input
+
+            Sequelize example
+            ```javascript
+              const { Op } = require("sequelize");
+
+              module.exports= async function(event, context) {
+                await Post.findAll({
+                  where: {
+                    [Op.or]: [
+                      { authorId: event.authorID },
+                      { authorId: 13 }
+                    ]
+                  }
+                });
+              };
+            ```
+
+            ## Resources
+            - [OWASP sql injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_aws_lambda_sql_injection
+      line_number: 7
+      filename: /tmp/scan/mysql2_sql_injection.js
+      category_groups:
+        - PII
+        - Personal Data
+      parent_line_number: 7
+      snippet: asyncConn.execute("SELECT * FROM `admin_users` WHERE ID = " + event.admin.id)
+      fingerprint: 84ad7a8d4f19c9d729235bd7e1fcfe64_1
+    - rule:
+        cwe_ids:
+            - "89"
+        id: javascript_aws_lambda_sql_injection
+        title: SQL injection vulnerability detected.
+        description: |
+            ## Description
+            Including unsanitized data, such as user input or request data, in raw SQL queries makes your application vulnerable to SQL injection attacks.
+
+
+            ## Remediations
+
+            Use safe sql libraries methods which sanitze user input
+
+            Sequelize example
+            ```javascript
+              const { Op } = require("sequelize");
+
+              module.exports= async function(event, context) {
+                await Post.findAll({
+                  where: {
+                    [Op.or]: [
+                      { authorId: event.authorID },
+                      { authorId: 13 }
+                    ]
+                  }
+                });
+              };
+            ```
+
+            ## Resources
+            - [OWASP sql injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_aws_lambda_sql_injection
+      line_number: 11
+      filename: /tmp/scan/mysql2_sql_injection.js
+      category_groups:
+        - PII
+        - Personal Data
+      parent_line_number: 11
+      snippet: |-
+        pool.query("SELECT * FROM users WHERE name = " + event.user_name, function() {
+            // do something
+          })
+      fingerprint: 84ad7a8d4f19c9d729235bd7e1fcfe64_2
+    - rule:
+        cwe_ids:
+            - "89"
+        id: javascript_aws_lambda_sql_injection
+        title: SQL injection vulnerability detected.
+        description: |
+            ## Description
+            Including unsanitized data, such as user input or request data, in raw SQL queries makes your application vulnerable to SQL injection attacks.
+
+
+            ## Remediations
+
+            Use safe sql libraries methods which sanitze user input
+
+            Sequelize example
+            ```javascript
+              const { Op } = require("sequelize");
+
+              module.exports= async function(event, context) {
+                await Post.findAll({
+                  where: {
+                    [Op.or]: [
+                      { authorId: event.authorID },
+                      { authorId: 13 }
+                    ]
+                  }
+                });
+              };
+            ```
+
+            ## Resources
+            - [OWASP sql injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_aws_lambda_sql_injection
+      line_number: 15
+      filename: /tmp/scan/mysql2_sql_injection.js
+      category_groups:
+        - PII
+        - Personal Data
+      parent_line_number: 15
+      snippet: |-
+        conn.query("SELECT * FROM users WHERE name = " + event.user_name, function() {
+              // do something
+            })
+      fingerprint: 84ad7a8d4f19c9d729235bd7e1fcfe64_3
 

--- a/javascript/express/insecure_allow_origin.yml
+++ b/javascript/express/insecure_allow_origin.yml
@@ -43,7 +43,7 @@ auxiliary:
           - variable: ORIGIN
             regex: (?i)['"]access-control-allow-origin["']
           - variable: USER_INPUT
-            detection: javascript_express_external_resource_req_object
+            detection: javascript_express_insecure_allow_origin_req_object
 metadata:
   description: "Insecure Access-Control-Allow-Origin detected."
   remediation_message: |

--- a/javascript/express/insecure_allow_origin/.snapshots/insecure_allow_origin.yml
+++ b/javascript/express/insecure_allow_origin/.snapshots/insecure_allow_origin.yml
@@ -1,2 +1,46 @@
-{}
+low:
+    - rule:
+        cwe_ids:
+            - "346"
+        id: javascript_express_insecure_allow_origin
+        title: Insecure Access-Control-Allow-Origin detected.
+        description: |
+            ## Description
+            Do not use unverified user-defined input to define Access-Control-Allow-Origin. This can lead to unintended user access to sensitive data.
+
+            ## Remediations
+            ❌ Avoid defining origins with user input wherever possible.
+
+            ✅ If unavoidable, be sure to verify the input or to use a safe-list.
+
+            ## Resources
+            - [OWASP Origin & Access-Control-Allow-Origin](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_insecure_allow_origin
+      line_number: 10
+      filename: /tmp/scan/insecure_allow_origin.js
+      parent_line_number: 10
+      snippet: 'res.writeHead(200, { "Access-Control-Allow-Origin": req.params.origin })'
+      fingerprint: 93ea1d55cdb7f9d1b5cd99ae732e4f40_0
+    - rule:
+        cwe_ids:
+            - "346"
+        id: javascript_express_insecure_allow_origin
+        title: Insecure Access-Control-Allow-Origin detected.
+        description: |
+            ## Description
+            Do not use unverified user-defined input to define Access-Control-Allow-Origin. This can lead to unintended user access to sensitive data.
+
+            ## Remediations
+            ❌ Avoid defining origins with user input wherever possible.
+
+            ✅ If unavoidable, be sure to verify the input or to use a safe-list.
+
+            ## Resources
+            - [OWASP Origin & Access-Control-Allow-Origin](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_insecure_allow_origin
+      line_number: 11
+      filename: /tmp/scan/insecure_allow_origin.js
+      parent_line_number: 11
+      snippet: res.set("access-control-allow-origin", origin)
+      fingerprint: 93ea1d55cdb7f9d1b5cd99ae732e4f40_1
 

--- a/javascript/express/sql_injection.yml
+++ b/javascript/express/sql_injection.yml
@@ -5,10 +5,7 @@ patterns:
       - variable: USER_INPUT
         detection: javascript_express_sql_injection_request_input
       - variable: KNEX_CLIENT
-        values:
-          - knex
-          - knexClient
-          - client
+        detection: javascript_express_sql_injection_knex_client
       - variable: METHOD
         values:
           - fromRaw
@@ -80,6 +77,15 @@ auxiliary:
         filters:
           - variable: MYSQL_POOL
             detection: javascript_express_sql_injection_mysql_pool
+  - id: javascript_express_sql_injection_knex_client
+    patterns:
+      - pattern: $<KNEX_CLIENT_INIT>
+        filters:
+          - variable: KNEX_CLIENT_INIT
+            values:
+              - knex
+              - knexClient
+              - client
 languages:
   - javascript
 severity: high

--- a/javascript/express/sql_injection/.snapshots/knex_sql_injection.yml
+++ b/javascript/express/sql_injection/.snapshots/knex_sql_injection.yml
@@ -1,2 +1,56 @@
-{}
+high:
+    - rule:
+        cwe_ids:
+            - "89"
+        id: javascript_express_sql_injection
+        title: SQL injection vulnerability detected.
+        description: |
+            ## Description
+            Including unsanitized data, such as user input or request data, in raw SQL queries makes your application vulnerable to SQL injection attacks.
+
+            ## Remediations
+
+            ❌ Avoid raw queries, especially those that contain unsanitized user input
+
+            ```javascript
+              var sqlite = new Sequelize("sqlite::memory:");
+              sqlite.query("SELECT * FROM users WHERE ID = " + req.params.userId);
+            ```
+
+            Instead, consider the following approaches when writing SQL queries
+
+            ✅ Validate query input wherever possible
+
+            ```javascript
+              var rawId = req.params.userId
+              if !(/[0-9]+/.test(rawId)) {
+                // input is unexpected; don't make the query
+              }
+            ```
+
+            ✅ Use prepared (or parameterized) statements when querying
+
+            Sequelize example -
+            ```javascript
+              var sqlite = new Sequelize("sqlite::memory:");
+              sqlite.query(
+                "SELECT * FROM users WHERE ID = ?",
+                { replacements: [req.params.userId] },
+                type: sequelize.QueryTypes.SELECT
+              )
+            ```
+
+            ## Resources
+            - [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+            - [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_sql_injection
+      line_number: 6
+      filename: /tmp/scan/knex_sql_injection.js
+      parent_line_number: 6
+      snippet: |-
+        knex
+        		.select("user.cart_details")
+        		.from("users")
+        		.whereRaw("name = " + req.query.user.name)
+      fingerprint: cf13cb6e5d474362f61d0fad5467b55e_0
 

--- a/javascript/lang/jwt_hardcoded_secret.yml
+++ b/javascript/lang/jwt_hardcoded_secret.yml
@@ -5,6 +5,18 @@ patterns:
       - variable: STRING_LITERAL
         detection: string_literal
         contains: false
+  - pattern: |
+      $<JOSE>.sign($<STRING_LITERAL>)
+    filters:
+      - variable: JOSE
+        detection: javascript_lang_jwt_hardcoded_secret_jose
+      - variable: STRING_LITERAL
+        detection: string_literal
+        contains: false
+auxiliary:
+  - id: javascript_lang_jwt_hardcoded_secret_jose
+    patterns:
+      - new jose.SignJWT()
 languages:
   - javascript
 severity: high

--- a/javascript/lang/jwt_hardcoded_secret/.snapshots/unsecure_jose_jwt.yml
+++ b/javascript/lang/jwt_hardcoded_secret/.snapshots/unsecure_jose_jwt.yml
@@ -1,2 +1,62 @@
-{}
+high:
+    - rule:
+        cwe_ids:
+            - "798"
+        id: javascript_lang_jwt_hardcoded_secret
+        title: Hardcoded jwt secret deteted
+        description: |
+            ## Description
+
+            Code is not a secure place to store secrets, use environment variables instead.
+
+            ## Remediations
+
+            Use environment variables
+
+            ```javascript
+              var jwt = require("jsonwebtoken");
+
+              var token = jwt.sign({ foo: "bar" }, process.env.JWT_SECRET);
+            ```
+
+            ## Resources
+            - [OWASP hardcoded passwords](https://owasp.org/www-community/vulnerabilities/Use_of_hard-coded_password)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_jwt_hardcoded_secret
+      line_number: 5
+      filename: /tmp/scan/unsecure_jose_jwt.js
+      parent_line_number: 5
+      snippet: |-
+        new jose.SignJWT({ 'urn:example:claim': true })
+          .setIssuedAt()
+          .setExpirationTime('2h')
+          .sign(secret)
+      fingerprint: 64e0c9a50fa93c2e14540fa7355c0478_0
+    - rule:
+        cwe_ids:
+            - "798"
+        id: javascript_lang_jwt_hardcoded_secret
+        title: Hardcoded jwt secret deteted
+        description: |
+            ## Description
+
+            Code is not a secure place to store secrets, use environment variables instead.
+
+            ## Remediations
+
+            Use environment variables
+
+            ```javascript
+              var jwt = require("jsonwebtoken");
+
+              var token = jwt.sign({ foo: "bar" }, process.env.JWT_SECRET);
+            ```
+
+            ## Resources
+            - [OWASP hardcoded passwords](https://owasp.org/www-community/vulnerabilities/Use_of_hard-coded_password)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_jwt_hardcoded_secret
+      line_number: 10
+      filename: /tmp/scan/unsecure_jose_jwt.js
+      parent_line_number: 10
+      snippet: (new jose.SignJWT()).sign(secret)
+      fingerprint: 64e0c9a50fa93c2e14540fa7355c0478_1
 

--- a/javascript/lang/jwt_hardcoded_secret/testdata/secure.js
+++ b/javascript/lang/jwt_hardcoded_secret/testdata/secure.js
@@ -10,4 +10,6 @@ const jwt = await new jose.SignJWT({ 'urn:example:claim': true })
   .setExpirationTime('2h')
   .sign(config.secret)
 
+const jwt2 = await (new jose.SignJWT()).sign(config.secret)
+
 console.log(jwt)

--- a/javascript/lang/jwt_hardcoded_secret/testdata/unsecure_jose_jwt.js
+++ b/javascript/lang/jwt_hardcoded_secret/testdata/unsecure_jose_jwt.js
@@ -7,6 +7,6 @@ const jwt = await new jose.SignJWT({ 'urn:example:claim': true })
   .setExpirationTime('2h')
   .sign(secret)
 
-const jwt2 = await new jose.SignJWT().sign(config.secret)
+const jwt2 = await (new jose.SignJWT()).sign(secret)
 
 console.log(jwt)


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Makes the following fixes to Javascript rules:
- `javascript_aws_lambda_sql_injection` and `javascript_express_insecure_allow_origin` - use local aux rules (were accidentally referencing other rules)
- `javascript_express_sql_injection` - Support chained knex calls
- `javascript_lang_jwt_hardcoded_secret` - Fix Jose rule

## Related
- Close https://github.com/Bearer/bearer-rules/issues/20
- Close https://github.com/Bearer/bearer/issues/884
- Close https://github.com/Bearer/bearer/issues/883
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
