### PR TITLE
feat(express): improve insecure allow origin rule

### DIFF
--- a/javascript/express/insecure_allow_origin.yml
+++ b/javascript/express/insecure_allow_origin.yml
@@ -6,6 +6,7 @@ patterns:
         values:
           - set
           - header
+          - setHeader
       - variable: ORIGIN
         regex: (?i)['"]access-control-allow-origin["']
       - variable: USER_INPUT

--- a/javascript/express/insecure_allow_origin/.snapshots/insecure_allow_origin_query.yml
+++ b/javascript/express/insecure_allow_origin/.snapshots/insecure_allow_origin_query.yml
@@ -1,0 +1,24 @@
+low:
+    - rule:
+        cwe_ids:
+            - "346"
+        id: javascript_express_insecure_allow_origin
+        title: Insecure Access-Control-Allow-Origin detected.
+        description: |
+            ## Description
+            Do not use unverified user-defined input to define Access-Control-Allow-Origin. This can lead to unintended user access to sensitive data.
+
+            ## Remediations
+            ❌ Avoid defining origins with user input wherever possible.
+
+            ✅ If unavoidable, be sure to verify the input or to use a safe-list.
+
+            ## Resources
+            - [OWASP Origin & Access-Control-Allow-Origin](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_insecure_allow_origin
+      line_number: 10
+      filename: /tmp/scan/insecure_allow_origin_query.js
+      parent_line_number: 10
+      snippet: res.setHeader("Access-Control-Allow-Origin", origin)
+      fingerprint: 49a2ac19530ed11cedad02ca90fdf7bc_0
+

--- a/javascript/express/insecure_allow_origin/testdata/insecure_allow_origin_query.js
+++ b/javascript/express/insecure_allow_origin/testdata/insecure_allow_origin_query.js
@@ -1,0 +1,11 @@
+var express = require("express")
+var helmet = require("helmet")
+
+var app = express()
+app.use(helmet())
+app.use(helmet.hidePoweredBy())
+
+app.get("/insecure", (req, res) => {
+  var origin = req.query.origin
+  res.setHeader("Access-Control-Allow-Origin", origin)
+})

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -36,6 +36,7 @@ for dir in $(find $TARGET -type d -name "testdata"); do
     test_snapshot=${test_snapshot%.*}.yml
     filename=$(basename $file)
 
+    # docker rmi bearer/bearer:latest-amd64
     docker run --platform linux/amd64 --rm -v $dir:/tmp/scan -v $PWD:/tmp/rules bearer/bearer:latest-amd64 scan /tmp/scan/$filename --only-rule=$rule_id --disable-default-rules=true --external-rule-dir=/tmp/rules --format=yaml > $test_result
 
     if [ -n "$UPDATE_SNAPSHOTS" ] || [ ! -f $test_snapshot ]; then


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Detect `setHeader` in express 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
