### PR TITLE
ci: cancel previous tests on the same branch

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,4 +1,5 @@
 name: Integration Tests
+
 on:
   push:
     branches:
@@ -8,8 +9,14 @@ on:
       - opened
       - synchronize
       - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Change the integration tests workflow to cancel previous jobs on the same branch.

Currently if you push additional changes when the tests are running, we tie up resources continuing to run the tests against the old commit.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
