### PR TITLE
fix: typo in ruby command injection rule

### DIFF
--- a/ruby/lang/exec_using_user_input.yml
+++ b/ruby/lang/exec_using_user_input.yml
@@ -60,7 +60,7 @@ patterns:
       - variable: USER_INPUT
         detection: ruby_lang_exec_using_user_input_user_input
   - pattern: |
-      `{$<...>$<USER_INPUT>$<...>`
+      `$<...>$<USER_INPUT>$<...>`
     filters:
       - variable: USER_INPUT
         detection: ruby_lang_exec_using_user_input_user_input


### PR DESCRIPTION
## Description
Removes rogue character from rule pattern.

This did not seem to affect the detection (see https://github.com/Bearer/bearer-rules/blob/main/ruby/lang/exec_using_user_input/.snapshots/unsafe_stdlib.yml#L378) but it's confusing nonetheless. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
