### PR TITLE
fix: case sensitivity in JWT JS rules

### DIFF
--- a/javascript/express/hardcoded_secret.yml
+++ b/javascript/express/hardcoded_secret.yml
@@ -3,7 +3,7 @@ patterns:
       $<MODULE>($<HARDCODED_SECRET_IN_HASH>)
     filters:
       - variable: MODULE
-        regex: (?i)(jwt|expressjwt|session)
+        regex: (?i)\A(jwt|expressjwt|session)\z
       - variable: HARDCODED_SECRET_IN_HASH
         detection: javascript_express_hardcoded_secret_in_hash
 languages:

--- a/javascript/express/hardcoded_secret.yml
+++ b/javascript/express/hardcoded_secret.yml
@@ -3,10 +3,7 @@ patterns:
       $<MODULE>($<HARDCODED_SECRET_IN_HASH>)
     filters:
       - variable: MODULE
-        values:
-          - jwt
-          - expressjwt
-          - session
+        regex: (?i)(jwt|expressjwt|session)
       - variable: HARDCODED_SECRET_IN_HASH
         detection: javascript_express_hardcoded_secret_in_hash
 languages:

--- a/javascript/express/jwt_not_revoked.yml
+++ b/javascript/express/jwt_not_revoked.yml
@@ -3,7 +3,7 @@ patterns:
       $<EXPRESS_JWT>($<HASH_CONTENT>)
     filters:
       - variable: EXPRESS_JWT
-        regex: (?i)(expressjwt)
+        regex: (?i)\A(expressjwt)\z
       - variable: HASH_CONTENT
         detection: javascript_express_jwt_not_revoked_secret
       - not:

--- a/javascript/express/jwt_not_revoked.yml
+++ b/javascript/express/jwt_not_revoked.yml
@@ -1,7 +1,9 @@
 patterns:
   - pattern: |
-      expressjwt($<HASH_CONTENT>)
+      $<EXPRESS_JWT>($<HASH_CONTENT>)
     filters:
+      - variable: EXPRESS_JWT
+        regex: (?i)(expressjwt)
       - variable: HASH_CONTENT
         detection: javascript_express_jwt_not_revoked_secret
       - not:

--- a/javascript/express/jwt_not_revoked/.snapshots/express_jwt_not_revoked.yml
+++ b/javascript/express/jwt_not_revoked/.snapshots/express_jwt_not_revoked.yml
@@ -27,4 +27,60 @@ low:
       parent_line_number: 11
       snippet: 'expressjwt({ secret: config.secret, algorithms: ["HS256"] })'
       fingerprint: a40f7810484e914bb4ae52d4f4b71100_0
+    - rule:
+        cwe_ids:
+            - "525"
+        id: javascript_express_jwt_not_revoked
+        title: Unrevoked JWT detected.
+        description: |
+            ## Description
+            The best practice caching policy is to revoke JWTs especially when these contain senstitive information.
+
+            ## Remediations
+            ✅ Ensure JWTs are short-lived by revoking them
+
+            ```javascript
+            expressjwt({
+              ...
+              isRevoked: this.customRevokeCall(),
+              ...
+            })
+            ```
+
+            ## Resources
+            - [ExpressJWT documentation on revoking tokens](https://github.com/auth0/express-jwt#revoked-tokens)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_jwt_not_revoked
+      line_number: 12
+      filename: /tmp/scan/express_jwt_not_revoked.js
+      parent_line_number: 12
+      snippet: 'expressJwt({ secret: config.secret, algorithms: ["HS256"] })'
+      fingerprint: a40f7810484e914bb4ae52d4f4b71100_1
+    - rule:
+        cwe_ids:
+            - "525"
+        id: javascript_express_jwt_not_revoked
+        title: Unrevoked JWT detected.
+        description: |
+            ## Description
+            The best practice caching policy is to revoke JWTs especially when these contain senstitive information.
+
+            ## Remediations
+            ✅ Ensure JWTs are short-lived by revoking them
+
+            ```javascript
+            expressjwt({
+              ...
+              isRevoked: this.customRevokeCall(),
+              ...
+            })
+            ```
+
+            ## Resources
+            - [ExpressJWT documentation on revoking tokens](https://github.com/auth0/express-jwt#revoked-tokens)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_express_jwt_not_revoked
+      line_number: 13
+      filename: /tmp/scan/express_jwt_not_revoked.js
+      parent_line_number: 13
+      snippet: 'ExpressJWT({ secret: config.secret, algorithms: ["HS256"] })'
+      fingerprint: a40f7810484e914bb4ae52d4f4b71100_2
 

--- a/javascript/express/jwt_not_revoked/testdata/express_jwt_not_revoked.js
+++ b/javascript/express/jwt_not_revoked/testdata/express_jwt_not_revoked.js
@@ -9,6 +9,8 @@ app.use(helmet.hidePoweredBy())
 app.get(
   "/unrevoked",
   expressjwt({ secret: config.secret, algorithms: ["HS256"] }),
+  expressJwt({ secret: config.secret, algorithms: ["HS256"] }),
+  ExpressJWT({ secret: config.secret, algorithms: ["HS256"] }),
   function (req, res) {
     if (!req.auth.admin) return res.sendStatus(401)
     res.sendStatus(200)


### PR DESCRIPTION
## Description

Match on juice-shop examples, which use `expressJwt` instead of `expressjwt`

Relates to #49 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [x] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
