### PR TITLE
feat: add template libaries to javascript raw html rule

### DIFF
--- a/javascript/lang/raw_html_using_user_input.yml
+++ b/javascript/lang/raw_html_using_user_input.yml
@@ -10,6 +10,152 @@ patterns:
       - not:
           variable: STRING
           detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: $<LIB>.$<METHOD>($<STRING>$<...>)
+    filters:
+      - variable: LIB
+        regex: \A(?i)dot\z
+      - variable: METHOD
+        values:
+          - compile
+          - template
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: ejs.$<METHOD>($<STRING>$<...>)
+    filters:
+      - variable: METHOD
+        values:
+          - compile
+          - render
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: Handlebars.$<METHOD>($<STRING>$<...>)
+    filters:
+      - variable: METHOD
+        values:
+          - compile
+          - precompile
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: Hogan.$<METHOD>($<STRING>$<...>)
+    filters:
+      - variable: METHOD
+        values:
+          - compile
+          - parse
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: $<OBJECT>.templates($<STRING>$<...>)
+    filters:
+      - variable: OBJECT
+        values:
+          - $
+          - jsrender
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  # lodash
+  - pattern: template($<STRING>$<...>)
+    filters:
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  # lodash or underscore
+  - pattern: $<LIB>.template($<STRING>$<...>)
+    filters:
+      - variable: LIB
+        values:
+          - _
+          - lodash
+          - underscore
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  # marko
+  - pattern: compiler.$<METHOD>($<STRING>$<...>)
+    filters:
+      - variable: METHOD
+        values:
+          - compile
+          - compileSync
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: Mustache.$<METHOD>($<STRING>$<...>)
+    filters:
+      - variable: METHOD
+        values:
+          - parse
+          - render
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: nunjucks.$<METHOD>($<STRING>$<...>)
+    filters:
+      - variable: METHOD
+        values:
+          - renderString
+          - compile
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: pug.$<METHOD>($<STRING>$<...>)
+    filters:
+      - variable: METHOD
+        values:
+          - render
+          - compile
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: Sqrl.$<METHOD>($<STRING>$<...>)
+    filters:
+      - variable: METHOD
+        values:
+          - render
+          - compile
+          - parse
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: Template7.compile($<STRING>$<...>)
+    filters:
+      - variable: STRING
+        detection: javascript_lang_raw_html_using_user_input_user_input
+      - not:
+          variable: STRING
+          detection: javascript_lang_raw_html_using_user_input_sanitized
+  - pattern: webix.ui($<TEMPLATE>)
+    filters:
+      - variable: TEMPLATE
+        detection: javascript_lang_raw_html_using_user_input_webix_template
 auxiliary:
   - id: javascript_lang_raw_html_using_user_input_user_input_source
     patterns:
@@ -35,6 +181,16 @@ auxiliary:
         filters:
           - variable: SANITIZED_USER_INPUT
             detection: javascript_lang_raw_html_using_user_input_user_input
+  - id: javascript_lang_raw_html_using_user_input_webix_template
+    patterns:
+      - pattern: |
+          { template: $<STRING> }
+        filters:
+          - variable: STRING
+            detection: javascript_lang_raw_html_using_user_input_user_input
+          - not:
+              variable: STRING
+              detection: javascript_lang_raw_html_using_user_input_sanitized
 severity: high
 metadata:
   description: "Unsanitized user input detected in raw HTML string."

--- a/javascript/lang/raw_html_using_user_input/.snapshots/bad.yml
+++ b/javascript/lang/raw_html_using_user_input/.snapshots/bad.yml
@@ -75,4 +75,543 @@ high:
       parent_line_number: 2
       snippet: '`<h1>${req.params.oops}</h1>`'
       fingerprint: a0a2333cacbf9549cd4f61e405954319_1
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 4
+      filename: /tmp/scan/bad.js
+      parent_line_number: 4
+      snippet: doT.compile(req.params.oops, {})
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_2
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 6
+      filename: /tmp/scan/bad.js
+      parent_line_number: 6
+      snippet: ejs.compile(req.params.oops, {})
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_3
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 8
+      filename: /tmp/scan/bad.js
+      parent_line_number: 8
+      snippet: Handlebars.compile(req.params.oops, {})
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_4
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 10
+      filename: /tmp/scan/bad.js
+      parent_line_number: 10
+      snippet: Hogan.parse(Hogan.scan(req.params.oops), null)
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_5
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 12
+      filename: /tmp/scan/bad.js
+      parent_line_number: 12
+      snippet: $.templates(req.params.oops)
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_6
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 14
+      filename: /tmp/scan/bad.js
+      parent_line_number: 14
+      snippet: template(req.params.oops, {})
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_7
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 15
+      filename: /tmp/scan/bad.js
+      parent_line_number: 15
+      snippet: _.template(req.params.oops, {})
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_8
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 17
+      filename: /tmp/scan/bad.js
+      parent_line_number: 17
+      snippet: compiler.compileSync(req.params.oops, "test.js")
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_9
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 19
+      filename: /tmp/scan/bad.js
+      parent_line_number: 19
+      snippet: Mustache.render(req.params.oops, {})
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_10
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 21
+      filename: /tmp/scan/bad.js
+      parent_line_number: 21
+      snippet: nunjucks.renderString(req.params.oops, {})
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_11
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 23
+      filename: /tmp/scan/bad.js
+      parent_line_number: 23
+      snippet: pug.render(req.params.oops, {})
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_12
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 25
+      filename: /tmp/scan/bad.js
+      parent_line_number: 25
+      snippet: Sqrl.render(req.params.oops, {})
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_13
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 27
+      filename: /tmp/scan/bad.js
+      parent_line_number: 27
+      snippet: Template7.compile(req.params.oops, {})
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_14
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_lang_raw_html_using_user_input
+        title: Unsanitized user input detected in raw HTML string.
+        description: |
+            ## Description
+
+            Applications should not include unsanitized user input in HTML. This
+            can allow cross-site scripting (XSS) attacks.
+
+            ## Remediations
+
+            ❌ Avoid including user input directly in HTML strings:
+
+            ```javascript
+            const html = `<h1>${req.params.title}</h1>`
+            ```
+
+            ✅ Use a framework or templating language to construct the HTML.
+
+            ✅ When HTML strings must be used, sanitize user input:
+
+            ```javascript
+            import sanitizeHtml from 'sanitize-html'
+
+            const sanitizedTitle = sanitizeHtml(req.params.title)
+            const html = `<h1>${sanitizedTitle}</h1>`
+            ```
+
+            ## Resources
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_raw_html_using_user_input
+      line_number: 29
+      filename: /tmp/scan/bad.js
+      parent_line_number: 29
+      snippet: |-
+        webix.ui({
+          id: "mylayout",
+          rows: [
+            { view: "toolbar", id: "mybar" },
+            { template: req.params.oops }
+          ]
+        })
+      fingerprint: a0a2333cacbf9549cd4f61e405954319_15
 

--- a/javascript/lang/raw_html_using_user_input/testdata/bad.js
+++ b/javascript/lang/raw_html_using_user_input/testdata/bad.js
@@ -1,2 +1,35 @@
 `<h1 class="test">${req.params.oops}</h1>`
 `<h1>${req.params.oops}</h1>`
+
+doT.compile(req.params.oops, {})
+
+ejs.compile(req.params.oops, {})
+
+Handlebars.compile(req.params.oops, {})
+
+Hogan.parse(Hogan.scan(req.params.oops), null)
+
+$.templates(req.params.oops)
+
+template(req.params.oops, {})
+_.template(req.params.oops, {})
+
+compiler.compileSync(req.params.oops, "test.js")
+
+Mustache.render(req.params.oops, {})
+
+nunjucks.renderString(req.params.oops, {})
+
+pug.render(req.params.oops, {})
+
+Sqrl.render(req.params.oops, {})
+
+Template7.compile(req.params.oops, {})
+
+webix.ui({
+  id: "mylayout",
+  rows: [
+    { view: "toolbar", id: "mybar" },
+    { template: req.params.oops }
+  ]
+})

--- a/javascript/lang/raw_html_using_user_input/testdata/ok.js
+++ b/javascript/lang/raw_html_using_user_input/testdata/ok.js
@@ -1,1 +1,34 @@
 `<h1>#{sanitizeHtml(req.params.ok)}</h1>`
+
+doT.compile(sanitizeHtml(req.params.ok), {})
+
+ejs.compile(sanitizeHtml(req.params.ok), {})
+
+Handlebars.compile(sanitizeHtml(req.params.ok), {})
+
+Hogan.parse(Hogan.scan(sanitizeHtml(req.params.ok)), null)
+
+$.templates(sanitizeHtml(req.params.ok))
+
+template(sanitizeHtml(req.params.ok), {})
+_.template(sanitizeHtml(req.params.ok), {})
+
+compiler.compileSync(sanitizeHtml(req.params.ok), "test.js")
+
+Mustache.render(sanitizeHtml(req.params.ok), {})
+
+nunjucks.renderString(sanitizeHtml(req.params.ok), {})
+
+pug.render(sanitizeHtml(req.params.ok), {})
+
+Sqrl.render(sanitizeHtml(req.params.ok), {})
+
+Template7.compile(sanitizeHtml(req.params.ok), {})
+
+webix.ui({
+  id: "mylayout",
+  rows: [
+    { view: "toolbar", id: "mybar" },
+    { template: sanitizeHtml(req.params.ok) }
+  ]
+})


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds support for detecting template strings (calls to libraries that render templates) containing user input to the Javascript raw HTML rule.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [x] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
