### PR TITLE
feat: add try method to ruby reflection rule

### DIFF
--- a/ruby/lang/reflection_using_user_input.yml
+++ b/ruby/lang/reflection_using_user_input.yml
@@ -32,6 +32,7 @@ patterns:
           - to_enum
           - send
           - public_send
+          - try
       - variable: USER_INPUT
         detection: ruby_lang_reflection_using_user_input_user_input
   - pattern: |
@@ -52,6 +53,7 @@ patterns:
           - to_enum
           - send
           - public_send
+          - try
       - variable: USER_INPUT
         detection: ruby_lang_reflection_using_user_input_user_input
   - pattern: |

--- a/ruby/lang/reflection_using_user_input/.snapshots/unsafe_rails.yml
+++ b/ruby/lang/reflection_using_user_input/.snapshots/unsafe_rails.yml
@@ -39,4 +39,44 @@ high:
       parent_line_number: 1
       snippet: params[:class].constantize
       fingerprint: 19d0863421c5f8efa748c585f083255e_0
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_reflection_using_user_input
+        title: Use of reflection influenced by user input detected.
+        description: |
+            ## Description
+
+            Applications should not look up or manipulate code using user-supplied data.
+
+            ## Remediations
+
+            ❌ Avoid using user input when using reflection:
+
+            ```ruby
+            method(params[:method])
+            ```
+
+            ✅ Use user input indirectly when using reflection:
+
+            ```ruby
+            method_name =
+              case params[:action]
+              when "option1"
+                "method1"
+              when "option2"
+                "method2"
+              end
+
+            method(method_name)
+            ```
+
+            ## Resources
+            - [OWASP Code injection explained](https://owasp.org/www-community/attacks/Code_Injection)
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_reflection_using_user_input
+      line_number: 3
+      filename: /tmp/scan/unsafe_rails.rb
+      parent_line_number: 3
+      snippet: current_user.try(params[:profession])
+      fingerprint: 19d0863421c5f8efa748c585f083255e_1
 

--- a/ruby/lang/reflection_using_user_input/testdata/unsafe_rails.rb
+++ b/ruby/lang/reflection_using_user_input/testdata/unsafe_rails.rb
@@ -1,1 +1,3 @@
 params[:class].constantize
+
+raise if current_user.try(params[:profession]) == "hacker"


### PR DESCRIPTION
## Description
Add `try` method to ruby reflection using user input rule. The `try` method is similar to e.g. `public_send` and calling it with untrusted input poses a security risk

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
