### PR TITLE
fix: add no config case to DOMpurify JS rule

### DIFF
--- a/javascript/third_parties/dom_purify.yml
+++ b/javascript/third_parties/dom_purify.yml
@@ -5,6 +5,8 @@ patterns:
       - not:
           variable: CONFIG
           detection: javascript_dom_purify_safe_config
+  - |
+    DOMPurify.sanitize($<_>)
 auxiliary:
   - id: javascript_dom_purify_safe_config
     patterns:

--- a/javascript/third_parties/dom_purify/.snapshots/unsecure.yml
+++ b/javascript/third_parties/dom_purify/.snapshots/unsecure.yml
@@ -29,4 +29,34 @@ high:
       parent_line_number: 2
       snippet: DOMPurify.sanitize(dirty, config)
       fingerprint: a247541d444b7e9242c4bb23a87bd55a_0
+    - rule:
+        cwe_ids:
+            - "79"
+        id: javascript_third_parties_dom_purify
+        title: Unsecure use of DOMPurify detected.
+        description: |
+            ## Description
+            There are XSS vulnerabilites when using DOMPurify's sanitize without proper configuration
+
+            ## Remediations
+
+            Specify a secure configuration option:
+            ```
+              DOMPurify.sanitize(htmlToSanitize, { RETURN_DOM_IMPORT:true })
+            ```
+
+            or:
+
+            ```
+              DOMPurify.sanitize(htmlToSanitize, { RETURN_DOM_FRAGMENT: true })
+            ```
+
+            ## Resources
+            - [Vulnerability explained](https://research.securitum.com/mutation-xss-via-mathml-mutation-dompurify-2-0-17-bypass)
+        documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_dom_purify
+      line_number: 5
+      filename: /tmp/scan/unsecure.js
+      parent_line_number: 5
+      snippet: DOMPurify.sanitize(dirty)
+      fingerprint: a247541d444b7e9242c4bb23a87bd55a_1
 

--- a/javascript/third_parties/dom_purify/testdata/secure.js
+++ b/javascript/third_parties/dom_purify/testdata/secure.js
@@ -1,3 +1,3 @@
 const config = { RETURN_DOM_FRAGMENT: true };
-let html = DOMPurify.sanitize(dirty);
+let html = DOMPurify.sanitize(dirty, config);
 document.body.innerHTML = html;

--- a/javascript/third_parties/dom_purify/testdata/unsecure.js
+++ b/javascript/third_parties/dom_purify/testdata/unsecure.js
@@ -1,3 +1,5 @@
 const config = {};
 const html = DOMPurify.sanitize(dirty, config);
 document.body.innerHTML = html;
+
+const body = DOMPurify.sanitize(dirty);


### PR DESCRIPTION
## Description

Extends existing rule to catch cases where no config is set when using `DOMpurify.sanitize`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
