### PR TITLE
ci: add canary release workflow

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,51 @@
+name: Canary
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  GH_USER: "bearer-bot"
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bump version and push tag
+        if: startsWith(github.ref, 'refs/tags') != true
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: v
+          default_bump: patch
+          append_to_pre_release_tag: canary
+    outputs:
+      ref: refs/tags/${{ steps.tag_version.outputs.new_tag || github.ref_name }}
+      tag_name: ${{ steps.tag_version.outputs.new_tag || github.ref_name }}
+
+  build:
+    needs: [tag]
+    name: build-rules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: mkdir release
+      - name: Archive Ruby
+        run: tar -czvf release/ruby.tar.gz ./ruby/**/*.yml
+      - name: Archive JavaScript
+        run: tar -czvf release/javascript.tar.gz ./javascript/**/*.yml
+      - name: Archive Java
+        run: tar -czvf release/java.tar.gz ./java/**/*.yml
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          draft: true
+          artifacts: "release/*"
+          tag: ${{ needs.tag.outputs.tag_name }}
+          name: ${{ needs.tag.outputs.tag_name }}
+          generateReleaseNotes: true


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a new Canary Github workflow that creates a draft release. This will allow us to debug the packaging/release artifacts.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
