### PR TITLE
ci: don't package shared java rules

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Archive JavaScript
         run: tar -czvf release/javascript.tar.gz ./javascript/**/*.yml ./javascript/shared/**/*.yml
       - name: Archive Java
-        run: tar -czvf release/java.tar.gz ./java/**/*.yml ./java/shared/**/*.yml
+        run: tar -czvf release/java.tar.gz ./java/**/*.yml
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Archive JavaScript
         run: tar -czvf release/javascript.tar.gz ./javascript/**/*.yml ./javascript/shared/**/*.yml
       - name: Archive Java
-        run: tar -czvf release/java.tar.gz ./java/**/*.yml ./java/shared/**/*.yml
+        run: tar -czvf release/java.tar.gz ./java/**/*.yml
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

We don't have any shared Java rules yet so trying to package them causes an error.

We'll have to remember to add this back when we create the first shared rule.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
