### PR TITLE
fix: set severity to warning

### DIFF
--- a/ruby/rails/unsafe_mass_assignment.yml
+++ b/ruby/rails/unsafe_mass_assignment.yml
@@ -5,6 +5,7 @@ patterns:
         regex: (\:|"|')(role|admin|banned|account_id)["|']?
 languages:
   - ruby
+severity: warning
 metadata:
   description: "Possibly dangerous permitted parameter key detected."
   remediation_message: |

--- a/ruby/rails/unsafe_mass_assignment/.snapshots/unsafe.yml
+++ b/ruby/rails/unsafe_mass_assignment/.snapshots/unsafe.yml
@@ -1,4 +1,4 @@
-low:
+warning:
     - rule:
         cwe_ids:
             - "915"


### PR DESCRIPTION
## Description
Set severity level for new Rails mass assignment rule to `warning`

Oversight from https://github.com/Bearer/bearer-rules/pull/67

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
