### PR TITLE
feat: extend ruby reflection rule to include classify cases

### DIFF
--- a/ruby/lang/reflection_using_user_input.yml
+++ b/ruby/lang/reflection_using_user_input.yml
@@ -82,6 +82,8 @@ patterns:
         values:
           - constantize
           - safe_constantize
+          - classify.constantize
+          - classify.safe_constantize
 severity: high
 metadata:
   description: "Use of reflection influenced by user input detected."

--- a/ruby/lang/reflection_using_user_input/.snapshots/unsafe_rails.yml
+++ b/ruby/lang/reflection_using_user_input/.snapshots/unsafe_rails.yml
@@ -74,9 +74,49 @@ high:
             ## Resources
             - [OWASP Code injection explained](https://owasp.org/www-community/attacks/Code_Injection)
         documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_reflection_using_user_input
-      line_number: 3
+      line_number: 2
       filename: /tmp/scan/unsafe_rails.rb
-      parent_line_number: 3
-      snippet: current_user.try(params[:profession])
+      parent_line_number: 2
+      snippet: params[:oops].classify.safe_constantize
       fingerprint: 19d0863421c5f8efa748c585f083255e_1
+    - rule:
+        cwe_ids:
+            - "94"
+        id: ruby_lang_reflection_using_user_input
+        title: Use of reflection influenced by user input detected.
+        description: |
+            ## Description
+
+            Applications should not look up or manipulate code using user-supplied data.
+
+            ## Remediations
+
+            ❌ Avoid using user input when using reflection:
+
+            ```ruby
+            method(params[:method])
+            ```
+
+            ✅ Use user input indirectly when using reflection:
+
+            ```ruby
+            method_name =
+              case params[:action]
+              when "option1"
+                "method1"
+              when "option2"
+                "method2"
+              end
+
+            method(method_name)
+            ```
+
+            ## Resources
+            - [OWASP Code injection explained](https://owasp.org/www-community/attacks/Code_Injection)
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_reflection_using_user_input
+      line_number: 4
+      filename: /tmp/scan/unsafe_rails.rb
+      parent_line_number: 4
+      snippet: current_user.try(params[:profession])
+      fingerprint: 19d0863421c5f8efa748c585f083255e_2
 

--- a/ruby/lang/reflection_using_user_input/testdata/unsafe_rails.rb
+++ b/ruby/lang/reflection_using_user_input/testdata/unsafe_rails.rb
@@ -1,3 +1,5 @@
 params[:class].constantize
+params[:oops].classify.safe_constantize
 
 raise if current_user.try(params[:profession]) == "hacker"
+


### PR DESCRIPTION
## Description
Extend ruby reflection rule to include `params[:oops].classify.constantize` as a case of reflection with user input

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
