### PR TITLE
fix: extend rails open redirect rule

### DIFF
--- a/ruby/rails/open_redirect.yml
+++ b/ruby/rails/open_redirect.yml
@@ -11,7 +11,7 @@ languages:
 auxiliary:
   - id: ruby_rails_open_redirect_sanitized
     patterns:
-      - pattern: $<METHOD>($<...>$<!>$<_>$<...>)
+      - pattern: $<...>$<METHOD>($<...>$<!>$<_>$<...>)
         filters:
           - variable: METHOD
             regex: _(path|url)\z

--- a/ruby/rails/open_redirect/testdata/ok.rb
+++ b/ruby/rails/open_redirect/testdata/ok.rb
@@ -2,4 +2,8 @@ class OrdersController < ApplicationController
   def notify
     redirect_to some_route_url(params[:id]), status: :found
   end
+
+  def orders
+    redirect_to Rails.application.routes.url_helpers.orders_path(shop_id: params[:shop_id])
+  end
 end


### PR DESCRIPTION
## Description
Rule was matching if we had a chained `_path` or `_url` method, but these are safe. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
