### PR TITLE
fix: fix Rails SQL injection pattern

### DIFF
--- a/ruby/rails/sql_injection.yml
+++ b/ruby/rails/sql_injection.yml
@@ -79,33 +79,22 @@ auxiliary:
             contains: false
   - id: ruby_rails_sql_injection_safe_special_arg
     patterns:
-      - pattern: | # where(["attr = ?", params[:oops]])
+      - pattern:
+          | # where(["attr = ?", params[:oops]]) or where({ attr: params[:oops] })
           $<_>($<OBJECT_ARG>$<...>)
         filters:
           - variable: OBJECT_ARG
             detection: ruby_rails_sql_injection_safe_special_object_arg
-            contains: false
-      - pattern: | # User.where(["attr = ?", params[:oops]])
+      - pattern:
+          | # User.where(["attr = ?", params[:oops]]) or User.where({ attr: params[:oops] })
           $<_>.$<_>($<OBJECT_ARG>$<...>)
         filters:
           - variable: OBJECT_ARG
             detection: ruby_rails_sql_injection_safe_special_object_arg
-            contains: false
       - pattern: | # where("attr = ?", params[:oops])
           $<_>($<_>, $<...>$<!>$<_>$<...>)
       - pattern: | # User.where("attr = ?", params[:oops])
           $<_>.$<_>($<_>, $<...>$<!>$<_>$<...>)
-      - pattern: | # where({ attr: params[:oops] })
-          $<_>($<OBJECT_ARG>$<...>)
-        filters:
-          - variable: OBJECT_ARG
-            detection: ruby_rails_sql_injection_safe_special_object_arg
-            contains: false
-      - pattern: | # User.where({ attr: params[:oops] })
-          $<_>.$<_>($<OBJECT_ARG>$<...>)
-        filters:
-          - variable: OBJECT_ARG
-            detection: ruby_rails_sql_injection_safe_special_object_arg
       - pattern: | # where(attr: params[:oops])
           $<_>($<_>: $<!>$<_>)
       - pattern: | # User.where(attr: params[:oops])

--- a/ruby/rails/sql_injection.yml
+++ b/ruby/rails/sql_injection.yml
@@ -80,21 +80,42 @@ auxiliary:
   - id: ruby_rails_sql_injection_safe_special_arg
     patterns:
       - pattern: | # where(["attr = ?", params[:oops]])
-          $<_>([$<_>, $<...>$<!>$<_>$<...>]$<...>)
+          $<_>($<OBJECT_ARG>$<...>)
+        filters:
+          - variable: OBJECT_ARG
+            detection: ruby_rails_sql_injection_safe_special_object_arg
+            contains: false
       - pattern: | # User.where(["attr = ?", params[:oops]])
-          $<_>.$<_>([$<_>, $<...>$<!>$<_>$<...>]$<...>)
+          $<_>.$<_>($<OBJECT_ARG>$<...>)
+        filters:
+          - variable: OBJECT_ARG
+            detection: ruby_rails_sql_injection_safe_special_object_arg
+            contains: false
       - pattern: | # where("attr = ?", params[:oops])
           $<_>($<_>, $<...>$<!>$<_>$<...>)
       - pattern: | # User.where("attr = ?", params[:oops])
           $<_>.$<_>($<_>, $<...>$<!>$<_>$<...>)
       - pattern: | # where({ attr: params[:oops] })
-          $<_>({ $<_>: $<!>$<_> }$<...>)
+          $<_>($<OBJECT_ARG>$<...>)
+        filters:
+          - variable: OBJECT_ARG
+            detection: ruby_rails_sql_injection_safe_special_object_arg
+            contains: false
       - pattern: | # User.where({ attr: params[:oops] })
-          $<_>.$<_>({ $<_>: $<!>$<_> }$<...>)
+          $<_>.$<_>($<OBJECT_ARG>$<...>)
+        filters:
+          - variable: OBJECT_ARG
+            detection: ruby_rails_sql_injection_safe_special_object_arg
       - pattern: | # where(attr: params[:oops])
           $<_>($<_>: $<!>$<_>)
       - pattern: | # User.where(attr: params[:oops])
           $<_>.$<_>($<_>: $<!>$<_>)
+  - id: ruby_rails_sql_injection_safe_special_object_arg
+    patterns:
+      - |
+        [$<_>, $<...>$<!>$<_>$<...>]
+      - |
+        { $<_>: $<!>$<_> }
   - id: ruby_rails_sql_injection_sanitized
     patterns:
       - pattern: ActiveRecord::Base.connection.quote($<!>$<_>)

--- a/ruby/rails/sql_injection/testdata/ok_using_bind.rb
+++ b/ruby/rails/sql_injection/testdata/ok_using_bind.rb
@@ -6,3 +6,9 @@ User.find_sole_by(["attr = ?", params[:ok]])
 ActiveRecord::Base.connection.exec_query("SELECT ?", "test", [[nil, params[:ok]]])
 
 connection.select_all("SELECT ?", "test", [[nil, params[:ok]]])
+
+search_params = {
+  name: params[:name],
+  organization_id: params[:organization_id]
+}
+Project.find_by(search_params)


### PR DESCRIPTION
## Description

We're now catching cases like the following again

```
search_params = {
  name: params[:name],
  organization_id: params[:organization_id]
}
Project.find_by(search_params)
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
