### PR TITLE
ci: split out canary test and make it manual

### DIFF
--- a/.github/workflows/canary_integration_tests.yml
+++ b/.github/workflows/canary_integration_tests.yml
@@ -1,14 +1,7 @@
-name: Integration Tests
+name: Canary Integration Tests
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["latest"]
+        version: ["canary-amd64"]
         group:
           [
             "javascript/aws_lambda",


### PR DESCRIPTION
## Description
Split out canary testing and move it to a manual process.

PR's do not need to be working on next version as well as current.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
