### PR TITLE
fix: ruby open telemetry snapshot

### DIFF
--- a/ruby/third_parties/open_telemetry/.snapshots/datatypes_in_span_init_block.yml
+++ b/ruby/third_parties/open_telemetry/.snapshots/datatypes_in_span_init_block.yml
@@ -99,4 +99,48 @@ high:
         end
       fingerprint: 949ba3eb3d0c9c539480c41846520b5b_1
       old_fingerprint: 27a6debdf4bdb600970e3436f7790760_1
+    - rule:
+        cwe_ids:
+            - "201"
+        id: ruby_third_parties_open_telemetry
+        title: Sensitive data sent to Open Telemetry detected.
+        description: |
+            ## Description
+            Leaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Open Telemetry.
+
+            ## Remediations
+
+            When logging errors or events, ensure all sensitive data is removed.
+
+            ## Resources
+            - [Open Telemetry Docs](https://opentelemetry.io/docs/)
+        documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+      line_number: 11
+      full_filename: /tmp/scan/datatypes_in_span_init_block.rb
+      filename: .
+      data_type:
+        category_uuid: cef587dd-76db-430b-9e18-7b031e1a193b
+        name: Email Address
+      category_groups:
+        - PII
+        - Personal Data
+      source:
+        location:
+            start: 11
+            end: 11
+            column:
+                start: 38
+                end: 48
+      sink:
+        location:
+            start: 11
+            end: 11
+            column:
+                start: 3
+                end: 51
+        content: 'span.add_event("leaking data for #{user.email}")'
+      parent_line_number: 11
+      snippet: 'span.add_event("leaking data for #{user.email}")'
+      fingerprint: 949ba3eb3d0c9c539480c41846520b5b_2
+      old_fingerprint: 27a6debdf4bdb600970e3436f7790760_2
 


### PR DESCRIPTION
## Description

With an upcoming fix in Bearer's data type detector (current Canary release), we need to update a snapshot for Ruby's open telemetry rule. I believe this should have always returned 3 results and now, with the fix, it does. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
