### PR TITLE
feat(java): extend LDAP injection rule

### DIFF
--- a/java/lang/ldap_injection.yml
+++ b/java/lang/ldap_injection.yml
@@ -21,6 +21,7 @@ auxiliary:
   - id: java_lang_ldap_injection_context
     patterns:
       - pattern: $<LIB>$<CLASS> $<VARIABLE> = $<_>;
+        focus: VARIABLE
         filters:
           - variable: LIB
             regex: ^(javax.)?(naming.)?(directory.)?
@@ -29,13 +30,13 @@ auxiliary:
               - Context
               - DirContext
               - InitialDirContext
-          - focus: VARIABLE
-      - pattern: $<LIB>LdapContext $<_>
+      - pattern: $<LIB>LdapContext $<VARIABLE>
+        focus: VARIABLE
         filters:
           - variable: LIB
             regex: ^(javax.)?(naming.)?(ldap.)?
-          - focus: VARIABLE
-      - pattern: $<LIB>$<CLASS> $<_>
+      - pattern: $<LIB>$<CLASS> $<VARIABLE>
+        focus: VARIABLE
         filters:
           - variable: LIB
             regex: ^(javax.)?(naming.)?(event.)?
@@ -43,7 +44,6 @@ auxiliary:
             values:
               - EventContext
               - EventDirContext
-          - focus: VARIABLE
       # fallback
       - context;
       - ctx;

--- a/java/lang/ldap_injection.yml
+++ b/java/lang/ldap_injection.yml
@@ -3,14 +3,52 @@ patterns:
       $<CONTEXT>.search($<_>, $<USER_INPUT>$<...>)
     filters:
       - variable: CONTEXT
+        detection: java_lang_ldap_injection_context
+      - variable: USER_INPUT
+        detection: java_lang_ldap_injection_user_input
+  - pattern: |
+      $<CONTEXT>.$<METHOD>($<USER_INPUT>)
+    filters:
+      - variable: CONTEXT
+        detection: java_lang_ldap_injection_context
+      - variable: METHOD
         values:
-          - context
-          - ctx
-          - dirContext
-          - dirCtx
+          - list
+          - lookup
       - variable: USER_INPUT
         detection: java_lang_ldap_injection_user_input
 auxiliary:
+  - id: java_lang_ldap_injection_context
+    patterns:
+      - pattern: $<LIB>$<CLASS> $<VARIABLE> = $<_>;
+        filters:
+          - variable: LIB
+            regex: ^(javax.)?(naming.)?(directory.)?
+          - variable: CLASS
+            values:
+              - Context
+              - DirContext
+              - InitialDirContext
+          - focus: VARIABLE
+      - pattern: $<LIB>LdapContext $<_>
+        filters:
+          - variable: LIB
+            regex: ^(javax.)?(naming.)?(ldap.)?
+          - focus: VARIABLE
+      - pattern: $<LIB>$<CLASS> $<_>
+        filters:
+          - variable: LIB
+            regex: ^(javax.)?(naming.)?(event.)?
+          - variable: CLASS
+            values:
+              - EventContext
+              - EventDirContext
+          - focus: VARIABLE
+      # fallback
+      - context;
+      - ctx;
+      - dirContext;
+      - dirCtx;
   - id: java_lang_ldap_injection_user_input
     patterns:
       - pattern: |
@@ -39,8 +77,6 @@ auxiliary:
               - getParts
 languages:
   - java
-trigger:
-  match_on: presence
 metadata:
   description: "LDAP injection threat detected"
   remediation_message: |
@@ -72,7 +108,8 @@ metadata:
 
     ## References
     - [LDAP Injection](https://owasp.org/www-community/attacks/LDAP_Injection)
+    - [LDAP Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html)
   cwe_id:
     - 90
-  id: "java_lang_ldap_injection"
+  id: java_lang_ldap_injection
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_ldap_injection

--- a/java/lang/ldap_injection/.snapshots/ldap_injection.yml
+++ b/java/lang/ldap_injection/.snapshots/ldap_injection.yml
@@ -33,26 +33,27 @@ low:
 
             ## References
             - [LDAP Injection](https://owasp.org/www-community/attacks/LDAP_Injection)
+            - [LDAP Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html)
         documentation_url: https://docs.bearer.com/reference/rules/java_lang_ldap_injection
-      line_number: 13
+      line_number: 17
       full_filename: /tmp/scan/ldap_injection.java
       filename: .
       source:
         location:
-            start: 13
-            end: 13
+            start: 17
+            end: 17
             column:
                 start: 9
                 end: 53
       sink:
         location:
-            start: 13
-            end: 13
+            start: 17
+            end: 17
             column:
                 start: 9
                 end: 53
         content: dirContext.search(base, filter, filters, sc)
-      parent_line_number: 13
+      parent_line_number: 17
       snippet: dirContext.search(base, filter, filters, sc)
       fingerprint: 0bad406b42c52ab03e6e7a64c501440d_0
       old_fingerprint: 2bcbd76ec29b3df12d0f7329f70211ed_0

--- a/java/lang/ldap_injection/testdata/ldap_injection.java
+++ b/java/lang/ldap_injection/testdata/ldap_injection.java
@@ -1,3 +1,5 @@
+import javax.naming.directory.DirContext;
+
 public class Cls extends HttpServlet
 {
 
@@ -9,6 +11,8 @@ public class Cls extends HttpServlet
         String base = "ou=users,ou=system";
         Object[] filters = new Object[] {"First avenue"};
         javax.naming.directory.SearchControls sc = new javax.naming.directory.SearchControls();
+
+        DirContext dirContext = new InitialDirContext(env);
 
         dirContext.search(base, filter, filters, sc);
     }


### PR DESCRIPTION
## Description
Extend LDAP injection rule to include `lookup` and `list` methods

Relates to #44 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
