### PR TITLE
fix: clean Java regex patterns

### DIFF
--- a/java/lang/file_permission_others.yml
+++ b/java/lang/file_permission_others.yml
@@ -15,7 +15,7 @@ auxiliary:
       - pattern: $<FILES>.getPosixFilePermissions();
         filters:
           - variable: FILES
-            regex: ^(java.)?(nio.)?(file.)?Files
+            regex: \A(java\.nio\.file\.)?Files\z
 languages:
   - java
 severity: warning

--- a/java/lang/missing_integrity_check.yml
+++ b/java/lang/missing_integrity_check.yml
@@ -2,7 +2,7 @@ patterns:
   - pattern: $<CIPHER>.getInstance($<ALGORITHM>)
     filters:
       - variable: CIPHER
-        regex: ^(javax.)?(crypto.)?Cipher
+        regex: \A(javax\.crypto\.)?Cipher\z
       - variable: ALGORITHM
         string_regex: \/CBC\/PKCS5Padding\z
       - not:

--- a/java/lang/padding_oracle_encryption_vulnerability.yml
+++ b/java/lang/padding_oracle_encryption_vulnerability.yml
@@ -2,7 +2,7 @@ patterns:
   - pattern: $<CIPHER>.getInstance($<PADDING_ORACLE>)
     filters:
       - variable: CIPHER
-        regex: ^(javax.)?(crypto.)?Cipher
+        regex: \A(javax\.crypto\.)?Cipher\z
       - variable: PADDING_ORACLE
         string_regex: \/CBC\/PKCS5Padding\z
       - not:

--- a/java/lang/path_traversal.yml
+++ b/java/lang/path_traversal.yml
@@ -3,7 +3,7 @@ patterns:
       new $<METHOD>($<...>$<FILE_USER_INPUT>$<...>);
     filters:
       - variable: METHOD
-        regex: (java.)?(io.)?(File|FileReader|FileWriter|FileInputStream|FileOutputStream)
+        regex: \A(java\.io\.)?(File|FileReader|FileWriter|FileInputStream|FileOutputStream)\z
       - variable: FILE_USER_INPUT
         detection: java_lang_path_traversal_user_input
         scope: result
@@ -11,7 +11,7 @@ patterns:
       new $<METHOD>($<...>$<FILE_USER_INPUT>$<...>);
     filters:
       - variable: METHOD
-        regex: ^(javax.)?(activation.)?FileDataSource
+        regex: \A(javax\.activation\.)?FileDataSource\z
       - variable: FILE_USER_INPUT
         detection: java_lang_path_traversal_user_input
         scope: result
@@ -19,7 +19,7 @@ patterns:
       $<METHOD>($<...>$<FILE_USER_INPUT>$<...>);
     filters:
       - variable: METHOD
-        regex: ^(java.)?(io.)?(File.)?(createTempFile|createTempDirectory)
+        regex: \A(java\.io\.File\.)?(createTempFile|createTempDirectory)\z
       - variable: FILE_USER_INPUT
         detection: java_lang_path_traversal_user_input
         scope: result
@@ -27,7 +27,7 @@ patterns:
       $<METHOD>($<...>$<FILE_USER_INPUT>$<...>);
     filters:
       - variable: METHOD
-        regex: ^(java.)?(nio.)?(file.)?(Files.)?(createTempFile|createTempDirectory)
+        regex: \A(java\.nio\.file\.Files\.)?(createTempFile|createTempDirectory)\z
       - variable: FILE_USER_INPUT
         detection: java_lang_path_traversal_user_input
         scope: result
@@ -35,7 +35,7 @@ patterns:
       $<METHOD>($<...>$<FILE_USER_INPUT>$<...>);
     filters:
       - variable: METHOD
-        regex: ^(java.)?(nio.)?(file.)?(Paths.)?get
+        regex: \A(java\.nio\.file\.Paths\.)?get\z
       - variable: FILE_USER_INPUT
         detection: java_lang_path_traversal_user_input
         scope: result

--- a/java/lang/rsa_no_padding.yml
+++ b/java/lang/rsa_no_padding.yml
@@ -2,7 +2,7 @@ patterns:
   - pattern: $<CIPHER>.getInstance($<RSA_NO_PADDING>)
     filters:
       - variable: CIPHER
-        regex: ^(javax.)?(crypto.)?Cipher
+        regex: \A(javax\.crypto\.)?Cipher\z
       - variable: RSA_NO_PADDING
         string_regex: \ARSA\/.*\/NoPadding\z
 languages:

--- a/java/shared/lang/cipher_des_init.yml
+++ b/java/shared/lang/cipher_des_init.yml
@@ -5,7 +5,7 @@ patterns:
   - pattern: $<CIPHER>.getInstance($<DES_ALGORITHM>)
     filters:
       - variable: CIPHER
-        regex: ^(javax.)?(crypto.)?Cipher
+        regex: \A(javax\.crypto\.)?Cipher\z
       - variable: DES_ALGORITHM
         string_regex: DES(/.*)?
 metadata:

--- a/java/shared/lang/message_digest_md5_init.yml
+++ b/java/shared/lang/message_digest_md5_init.yml
@@ -5,7 +5,7 @@ patterns:
   - pattern: $<MESSAGE_DIGEST>.getInstance($<JAVA_SHARED_LANG_MESSAGE_DIGEST_MD5_INIT_ALGORITHM>)
     filters:
       - variable: MESSAGE_DIGEST
-        regex: ^(java.)?(security.)?MessageDigest
+        regex: \A(java\.security\.)?MessageDigest\z
       - variable: JAVA_SHARED_LANG_MESSAGE_DIGEST_MD5_INIT_ALGORITHM
         string_regex: MD5
 metadata:


### PR DESCRIPTION
## Description
Clean up Java type import regex patterns following https://github.com/Bearer/bearer-rules/pull/108#discussion_r1230999583

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
