### PR TITLE
fix(java): add encode method for XSS response writer

### DIFF
--- a/java/lang/xss_response_writer.yml
+++ b/java/lang/xss_response_writer.yml
@@ -47,7 +47,8 @@ auxiliary:
           response.getWriter()
   - id: java_lang_xss_response_writer_sanitized_input
     patterns:
-      - pattern: Encode.forHtml($<!>$<_>)
+      - Encode.forHtml($<!>$<_>)
+      - $<_>.encodeForHTML($<!>$<_>)
 languages:
   - java
 skip_data_types:


### PR DESCRIPTION
## Description
Add additional encode method to sanitizer pattern for Java's XSS response writer rule

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
