### PR TITLE
docs: update description ruby_lang_insecure_ftp

### DIFF
--- a/ruby/lang/insecure_ftp.yml
+++ b/ruby/lang/insecure_ftp.yml
@@ -23,7 +23,7 @@ metadata:
 
     ## Remediations
 
-    ✅ To ensure secure FTP connections are made, [use the `Net::SFTP` library](https://github.com/net-ssh/net-sftp) instead of `Net::FTP`:
+    ✅ To ensure secure FTP connections are made, use the Net::SFTP [library](https://github.com/net-ssh/net-sftp) instead of Net::FTP:
 
     ```ruby
     require 'net/sftp'

--- a/ruby/lang/insecure_ftp/.snapshots/ftp_new.yml
+++ b/ruby/lang/insecure_ftp/.snapshots/ftp_new.yml
@@ -11,7 +11,7 @@ medium:
 
             ## Remediations
 
-            ✅ To ensure secure FTP connections are made, [use the `Net::SFTP` library](https://github.com/net-ssh/net-sftp) instead of `Net::FTP`:
+            ✅ To ensure secure FTP connections are made, use the Net::SFTP [library](https://github.com/net-ssh/net-sftp) instead of Net::FTP:
 
             ```ruby
             require 'net/sftp'

--- a/ruby/lang/insecure_ftp/.snapshots/ftp_open.yml
+++ b/ruby/lang/insecure_ftp/.snapshots/ftp_open.yml
@@ -11,7 +11,7 @@ low:
 
             ## Remediations
 
-            ✅ To ensure secure FTP connections are made, [use the `Net::SFTP` library](https://github.com/net-ssh/net-sftp) instead of `Net::FTP`:
+            ✅ To ensure secure FTP connections are made, use the Net::SFTP [library](https://github.com/net-ssh/net-sftp) instead of Net::FTP:
 
             ```ruby
             require 'net/sftp'

--- a/ruby/lang/insecure_ftp/.snapshots/ftp_open_with_datatype.yml
+++ b/ruby/lang/insecure_ftp/.snapshots/ftp_open_with_datatype.yml
@@ -11,7 +11,7 @@ high:
 
             ## Remediations
 
-            ✅ To ensure secure FTP connections are made, [use the `Net::SFTP` library](https://github.com/net-ssh/net-sftp) instead of `Net::FTP`:
+            ✅ To ensure secure FTP connections are made, use the Net::SFTP [library](https://github.com/net-ssh/net-sftp) instead of Net::FTP:
 
             ```ruby
             require 'net/sftp'


### PR DESCRIPTION

## Description
current description for `ruby_lang_insecure_ftp` formats very badly update the markup a bit to make it more readable

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
