### PR TITLE
fix(java): make sql injection rule stricter

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -36,6 +36,7 @@ jobs:
             "ruby/rails",
             "ruby/third_parties",
             "java/lang",
+            "java/spring",
           ]
     steps:
       - uses: actions/checkout@v3

--- a/java/lang/sqli.yml
+++ b/java/lang/sqli.yml
@@ -1,23 +1,93 @@
+imports:
+  - java_shared_lang_instance
 patterns:
   - pattern: |
-      $<_>.$<METHOD>($<DYNAMIC_INPUT_LITERAL>)
+      $<CONNECTION>.$<METHOD>($<DYNAMIC_INPUT_LITERAL>$<...>);
     filters:
+      - variable: CONNECTION
+        detection: java_lang_sqli_connection
+        scope: cursor
       - variable: METHOD
         values:
-          - execute
-          - executeQuery
-          - executeUpdate
-          - executeLargeUpdate
-          - addBatch
-          - prepare
+          - nativeSQL
           - prepareCall
           - prepareStatement
-          - nativeSQL
+      - variable: DYNAMIC_INPUT_LITERAL
+        detection: java_lang_sqli_dynamic_input
+        scope: result
+  - pattern: |
+      $<STATEMENT>.$<METHOD>($<DYNAMIC_INPUT_LITERAL>$<...>);
+    filters:
+      - variable: STATEMENT
+        detection: java_lang_sqli_statement
+        scope: cursor
+      - variable: METHOD
+        values:
+          - addBatch
+          - execute
+          - executeLargeUpdate
+          - executeQuery
+          - executeUpdate
+      - variable: DYNAMIC_INPUT_LITERAL
+        detection: java_lang_sqli_dynamic_input
+        scope: result
+  - pattern: |
+      $<ENTITY_MANAGER>.$<METHOD>($<DYNAMIC_INPUT_LITERAL>$<...>);
+    filters:
+      - variable: ENTITY_MANAGER
+        detection: java_lang_sqli_entity_manager
+        scope: cursor
+      - variable: METHOD
+        values:
           - createNativeQuery
           - createQuery
       - variable: DYNAMIC_INPUT_LITERAL
         detection: java_lang_sqli_dynamic_input
+        scope: result
 auxiliary:
+  - id: java_lang_sqli_connection
+    patterns:
+      - pattern: $<CONNECTION_INSTANCE>;
+        filters:
+          - variable: CONNECTION_INSTANCE
+            detection: java_shared_lang_instance
+            scope: cursor
+            filters:
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.sql\.)?Connection\z
+      - $<_>.getConnection();
+      # fallback
+      - con;
+      - conn;
+      - connection;
+  - id: java_lang_sqli_statement
+    patterns:
+      - pattern: $<STATEMENT_INSTANCE>;
+        filters:
+          - variable: STATEMENT_INSTANCE
+            detection: java_shared_lang_instance
+            scope: cursor
+            filters:
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.sql\.)?Statement\z
+      - $<_>.createStatement();
+      # fallback
+      - stmt;
+      - statement;
+  - id: java_lang_sqli_entity_manager
+    patterns:
+      - pattern: $<ENTITY_INSTANCE>;
+        filters:
+          - variable: ENTITY_INSTANCE
+            detection: java_shared_lang_instance
+            scope: cursor
+            filters:
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(javax\.persistence\.)?EntityManager\z
+      - $<_>.createEntityManager();
+      # fallback
+      - em;
+      - entityManager;
   - id: java_lang_sqli_dynamic_input
     patterns:
       - pattern: |
@@ -25,11 +95,11 @@ auxiliary:
         filters:
           - variable: STRING_LITERAL
             detection: string_literal
-            contains: false
+            scope: cursor
           - not:
               variable: DYNAMIC_INPUT
               detection: string_literal
-              contains: false
+              scope: cursor
 languages:
   - java
 trigger:

--- a/java/lang/sqli/.snapshots/string_concatenation.yml
+++ b/java/lang/sqli/.snapshots/string_concatenation.yml
@@ -53,4 +53,274 @@ low:
       snippet: stmt.executeQuery(sqlQuery)
       fingerprint: 79d5d495c5c408c582b32582f1ae9171_0
       old_fingerprint: 8561d23bebc1cce1822c6a6f141f54cc_0
+    - rule:
+        cwe_ids:
+            - "89"
+        id: java_lang_sqli
+        title: Unsanitized user input in SQL query detected.
+        description: |
+            ## Description
+
+            Including unsanitized data, such as user input or request data, in raw SQL
+            queries makes your application vulnerable to SQL injection attacks.
+
+            ## Remediations
+
+            ❌ Avoid raw queries, especially those that contain unsanitized user input:
+
+            ```java
+              Statement stmt = conn.createStatement();
+              ResultSet rs = stmt.executeQuery("select name from users where id='"+ uri.getQueryParameter("user_id") "'")) {
+            ```
+
+            ✅ Instead of using dynamically crafted strings for your SQL queries, use prepared statements instead
+
+            ```java
+            myStmt = myCon.prepareStatement("select * from students where age > ? and name = ?");
+            myStmt.setInt(1, uri.getQueryParameter("age"));
+            myStmt.setString(2, uri.getQueryParameter("name"));
+            ```
+
+            ## Resources
+            - [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+            - [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/java_lang_sqli
+      line_number: 23
+      full_filename: /tmp/scan/string_concatenation.java
+      filename: .
+      source:
+        location:
+            start: 23
+            end: 23
+            column:
+                start: 10
+                end: 45
+      sink:
+        location:
+            start: 23
+            end: 23
+            column:
+                start: 10
+                end: 45
+        content: conn.prepareStatement(sqlQuery, 42)
+      parent_line_number: 23
+      snippet: conn.prepareStatement(sqlQuery, 42)
+      fingerprint: 79d5d495c5c408c582b32582f1ae9171_1
+      old_fingerprint: 8561d23bebc1cce1822c6a6f141f54cc_1
+    - rule:
+        cwe_ids:
+            - "89"
+        id: java_lang_sqli
+        title: Unsanitized user input in SQL query detected.
+        description: |
+            ## Description
+
+            Including unsanitized data, such as user input or request data, in raw SQL
+            queries makes your application vulnerable to SQL injection attacks.
+
+            ## Remediations
+
+            ❌ Avoid raw queries, especially those that contain unsanitized user input:
+
+            ```java
+              Statement stmt = conn.createStatement();
+              ResultSet rs = stmt.executeQuery("select name from users where id='"+ uri.getQueryParameter("user_id") "'")) {
+            ```
+
+            ✅ Instead of using dynamically crafted strings for your SQL queries, use prepared statements instead
+
+            ```java
+            myStmt = myCon.prepareStatement("select * from students where age > ? and name = ?");
+            myStmt.setInt(1, uri.getQueryParameter("age"));
+            myStmt.setString(2, uri.getQueryParameter("name"));
+            ```
+
+            ## Resources
+            - [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+            - [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/java_lang_sqli
+      line_number: 29
+      full_filename: /tmp/scan/string_concatenation.java
+      filename: .
+      source:
+        location:
+            start: 29
+            end: 29
+            column:
+                start: 7
+                end: 54
+      sink:
+        location:
+            start: 29
+            end: 29
+            column:
+                start: 7
+                end: 54
+        content: emf.createEntityManager().createQuery(sqlQuery)
+      parent_line_number: 29
+      snippet: emf.createEntityManager().createQuery(sqlQuery)
+      fingerprint: 79d5d495c5c408c582b32582f1ae9171_2
+      old_fingerprint: 8561d23bebc1cce1822c6a6f141f54cc_2
+    - rule:
+        cwe_ids:
+            - "89"
+        id: java_lang_sqli
+        title: Unsanitized user input in SQL query detected.
+        description: |
+            ## Description
+
+            Including unsanitized data, such as user input or request data, in raw SQL
+            queries makes your application vulnerable to SQL injection attacks.
+
+            ## Remediations
+
+            ❌ Avoid raw queries, especially those that contain unsanitized user input:
+
+            ```java
+              Statement stmt = conn.createStatement();
+              ResultSet rs = stmt.executeQuery("select name from users where id='"+ uri.getQueryParameter("user_id") "'")) {
+            ```
+
+            ✅ Instead of using dynamically crafted strings for your SQL queries, use prepared statements instead
+
+            ```java
+            myStmt = myCon.prepareStatement("select * from students where age > ? and name = ?");
+            myStmt.setInt(1, uri.getQueryParameter("age"));
+            myStmt.setString(2, uri.getQueryParameter("name"));
+            ```
+
+            ## Resources
+            - [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+            - [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/java_lang_sqli
+      line_number: 33
+      full_filename: /tmp/scan/string_concatenation.java
+      filename: .
+      source:
+        location:
+            start: 33
+            end: 33
+            column:
+                start: 7
+                end: 40
+      sink:
+        location:
+            start: 33
+            end: 33
+            column:
+                start: 7
+                end: 40
+        content: x.prepareStatement("select " + y)
+      parent_line_number: 33
+      snippet: x.prepareStatement("select " + y)
+      fingerprint: 79d5d495c5c408c582b32582f1ae9171_3
+      old_fingerprint: 8561d23bebc1cce1822c6a6f141f54cc_3
+    - rule:
+        cwe_ids:
+            - "89"
+        id: java_lang_sqli
+        title: Unsanitized user input in SQL query detected.
+        description: |
+            ## Description
+
+            Including unsanitized data, such as user input or request data, in raw SQL
+            queries makes your application vulnerable to SQL injection attacks.
+
+            ## Remediations
+
+            ❌ Avoid raw queries, especially those that contain unsanitized user input:
+
+            ```java
+              Statement stmt = conn.createStatement();
+              ResultSet rs = stmt.executeQuery("select name from users where id='"+ uri.getQueryParameter("user_id") "'")) {
+            ```
+
+            ✅ Instead of using dynamically crafted strings for your SQL queries, use prepared statements instead
+
+            ```java
+            myStmt = myCon.prepareStatement("select * from students where age > ? and name = ?");
+            myStmt.setInt(1, uri.getQueryParameter("age"));
+            myStmt.setString(2, uri.getQueryParameter("name"));
+            ```
+
+            ## Resources
+            - [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+            - [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/java_lang_sqli
+      line_number: 37
+      full_filename: /tmp/scan/string_concatenation.java
+      filename: .
+      source:
+        location:
+            start: 37
+            end: 37
+            column:
+                start: 7
+                end: 36
+      sink:
+        location:
+            start: 37
+            end: 37
+            column:
+                start: 7
+                end: 36
+        content: x.executeQuery("select " + y)
+      parent_line_number: 37
+      snippet: x.executeQuery("select " + y)
+      fingerprint: 79d5d495c5c408c582b32582f1ae9171_4
+      old_fingerprint: 8561d23bebc1cce1822c6a6f141f54cc_4
+    - rule:
+        cwe_ids:
+            - "89"
+        id: java_lang_sqli
+        title: Unsanitized user input in SQL query detected.
+        description: |
+            ## Description
+
+            Including unsanitized data, such as user input or request data, in raw SQL
+            queries makes your application vulnerable to SQL injection attacks.
+
+            ## Remediations
+
+            ❌ Avoid raw queries, especially those that contain unsanitized user input:
+
+            ```java
+              Statement stmt = conn.createStatement();
+              ResultSet rs = stmt.executeQuery("select name from users where id='"+ uri.getQueryParameter("user_id") "'")) {
+            ```
+
+            ✅ Instead of using dynamically crafted strings for your SQL queries, use prepared statements instead
+
+            ```java
+            myStmt = myCon.prepareStatement("select * from students where age > ? and name = ?");
+            myStmt.setInt(1, uri.getQueryParameter("age"));
+            myStmt.setString(2, uri.getQueryParameter("name"));
+            ```
+
+            ## Resources
+            - [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+            - [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/java_lang_sqli
+      line_number: 41
+      full_filename: /tmp/scan/string_concatenation.java
+      filename: .
+      source:
+        location:
+            start: 41
+            end: 41
+            column:
+                start: 7
+                end: 35
+      sink:
+        location:
+            start: 41
+            end: 41
+            column:
+                start: 7
+                end: 35
+        content: x.createQuery("select " + y)
+      parent_line_number: 41
+      snippet: x.createQuery("select " + y)
+      fingerprint: 79d5d495c5c408c582b32582f1ae9171_5
+      old_fingerprint: 8561d23bebc1cce1822c6a6f141f54cc_5
 

--- a/java/lang/sqli/testdata/safe.java
+++ b/java/lang/sqli/testdata/safe.java
@@ -19,8 +19,13 @@ public class FirstExample {
             System.out.print(", First: " + rs.getString("first"));
             System.out.println(", Last: " + rs.getString("last"));
          }
+
+         conn.prepareStatement(QUERY, 42);
       } catch (SQLException e) {
          e.printStackTrace();
-      } 
+      }
+
+      EntityManagerFactory emf = Persistence.createEntityManagerFactory("Student_details");
+      emf.createEntityManager().createQuery(QUERY);
    }
 }

--- a/java/lang/sqli/testdata/string_concatenation.java
+++ b/java/lang/sqli/testdata/string_concatenation.java
@@ -8,8 +8,8 @@ public class SQLExample {
    static final String PASS = "guest";
 
    public static void main(String[] args) {
+      String sqlQuery = "select name from users where id='"+ args[1] + "'";
 
-      String sqlQuery = "select name from users where id='"+ args[1] + "'"
       // Open a connection
       try(Connection conn = DriverManager.getConnection(DB_URL, USER, PASS);
          Statement stmt = conn.createStatement();
@@ -19,8 +19,25 @@ public class SQLExample {
             // Retrieve by column name
             System.out.println(", Name: " + rs.getString("name"));
          }
+
+         conn.prepareStatement(sqlQuery, 42);
       } catch (SQLException e) {
          e.printStackTrace();
-      } 
+      }
+
+      EntityManagerFactory emf=Persistence.createEntityManagerFactory("Student_details");
+      emf.createEntityManager().createQuery(sqlQuery);
+   }
+
+   public static void conTest(Connection x) {
+      x.prepareStatement("select " + y);
+   }
+
+   public static void stmtTest(Statement x) {
+      x.executeQuery("select " + y);
+   }
+
+   public static void emTest(EntityManager x) {
+      x.createQuery("select " + y);
    }
 }

--- a/java/lang/xss_servlet_parameter/.snapshots/bad.yml
+++ b/java/lang/xss_servlet_parameter/.snapshots/bad.yml
@@ -311,4 +311,56 @@ warning:
       snippet: e.getParameter("name")
       fingerprint: 3607f59a3e728c29a2d55ebb50fea480_5
       old_fingerprint: 373a2f78f8b24212b57fca600a04e945_5
+    - rule:
+        cwe_ids:
+            - "20"
+        id: java_lang_xss_servlet_parameter
+        title: Servlet request parameter methods detected.
+        description: |
+            ## Description
+
+            We should sanitize or validate any values from Servlet request GET and POST parameters. This is to protect our application from possible cross-site scripting (XSS) attacks.
+
+            ✅ Make sure to sanitize input from Servlet and HttpServlet requests. You can use a library like OWASP AntiSamy or Enterprise Security API (ESAPI) to do this.
+
+            ```java
+            public void main(ServletRequest request, ServletResponse response) {
+              AntiSamy antiSamy = new AntiSamy();
+              Policy policy = Policy.getInstance(POLICY_FILE_LOCATION);
+
+              String username = request.getParameter("username");
+              CleanResults cr = antiSamy.scan(username, policy);
+
+              // ...
+            }
+            ```
+
+            ## Resources
+
+            - [OWASP Cross-Site Scripting (XSS) Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+            - [OWASP AntiSamy](https://owasp.org/www-project-antisamy/)
+            - [OWASP ESAPI](https://owasp.org/www-project-enterprise-security-api/)
+        documentation_url: https://docs.bearer.com/reference/rules/java_lang_xss_servlet_parameter
+      line_number: 36
+      full_filename: /tmp/scan/bad.java
+      filename: .
+      source:
+        location:
+            start: 36
+            end: 36
+            column:
+                start: 7
+                end: 36
+      sink:
+        location:
+            start: 36
+            end: 36
+            column:
+                start: 7
+                end: 36
+        content: resource.getParameter("name")
+      parent_line_number: 36
+      snippet: resource.getParameter("name")
+      fingerprint: 3607f59a3e728c29a2d55ebb50fea480_6
+      old_fingerprint: 373a2f78f8b24212b57fca600a04e945_6
 

--- a/java/lang/xss_servlet_parameter/testdata/bad.java
+++ b/java/lang/xss_servlet_parameter/testdata/bad.java
@@ -31,5 +31,9 @@ public class Foo extends Servlet
     } catch (OtherException|HttpServletRequest e) {
       e.getParameter("name");
     }
+
+    try (ServletRequest resource = getReq()) {
+      resource.getParameter("name");
+    }
   }
 }

--- a/java/shared/lang/instance.yml
+++ b/java/shared/lang/instance.yml
@@ -25,6 +25,9 @@ patterns:
   # exception handler
   - pattern: try {} catch($<JAVA_SHARED_LANG_INSTANCE_TYPE> $<JAVA_SHARED_LANG_INSTANCE_VARIABLE>) {}
     focus: JAVA_SHARED_LANG_INSTANCE_VARIABLE
+  # resource block
+  - pattern: try ($<JAVA_SHARED_LANG_INSTANCE_TYPE> $<JAVA_SHARED_LANG_INSTANCE_VARIABLE> = $<_>) {}
+    focus: JAVA_SHARED_LANG_INSTANCE_VARIABLE
 metadata:
   description: "Java type instance"
   id: java_shared_lang_instance

--- a/java/shared/lang/instance.yml
+++ b/java/shared/lang/instance.yml
@@ -4,7 +4,7 @@ languages:
 patterns:
   - new $<JAVA_SHARED_LANG_INSTANCE_TYPE>();
   # local variable declaration
-  - pattern: $<JAVA_SHARED_LANG_INSTANCE_TYPE> $<JAVA_SHARED_LANG_INSTANCE_VARIABLE> = $<_>;
+  - pattern: $<...>$<JAVA_SHARED_LANG_INSTANCE_TYPE> $<JAVA_SHARED_LANG_INSTANCE_VARIABLE> = $<_>;
   # class field
   - pattern: |
       class $<...>$<_> $<...>{

--- a/java/spring/sqli.yml
+++ b/java/spring/sqli.yml
@@ -1,13 +1,39 @@
+imports:
+  - java_shared_lang_instance
 patterns:
-  - pattern: |
-      $<_>.$<METHOD>($<DYNAMIC_INPUT_LITERAL>)
+  - pattern: new $<CLASS>($<DYNAMIC_INPUT_LITERAL>$<...>);
     filters:
+      - variable: CLASS
+        regex: \A(org\.springframework\.jdbc\.core\.)?PreparedStatementCreatorFactory\z
+      - variable: DYNAMIC_INPUT_LITERAL
+        detection: java_spring_sqli_dynamic_input
+        scope: result
+  - pattern: $<FACTORY>.newPreparedStatementCreator($<DYNAMIC_INPUT_LITERAL>$<...>);
+    filters:
+      - variable: FACTORY
+        detection: java_shared_lang_instance
+        scope: cursor
+        filters:
+          - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+            regex: \A(org\.springframework\.jdbc\.core\.)?PreparedStatementCreatorFactory\z
+      - variable: DYNAMIC_INPUT_LITERAL
+        detection: java_spring_sqli_dynamic_input
+        scope: result
+  - pattern: $<JDBC_TEMPLATE>.batchUpdate($<...>$<DYNAMIC_INPUT_LITERAL>$<...>);
+    filters:
+      - variable: JDBC_TEMPLATE
+        detection: java_spring_sqli_jdbc_template
+        scope: cursor
+      - variable: DYNAMIC_INPUT_LITERAL
+        detection: java_spring_sqli_dynamic_input
+        scope: result
+  - pattern: $<JDBC_TEMPLATE>.$<METHOD>($<DYNAMIC_INPUT_LITERAL>$<...>);
+    filters:
+      - variable: JDBC_TEMPLATE
+        detection: java_spring_sqli_jdbc_template
+        scope: cursor
       - variable: METHOD
         values:
-          - PreparedStatementCreatorFactory
-          - newPreparedStatementCreator
-          - update
-          - batchUpdate
           - execute
           - query
           - queryForList
@@ -17,9 +43,23 @@ patterns:
           - queryForInt
           - queryForLong
           - queryForStream
+          - update
       - variable: DYNAMIC_INPUT_LITERAL
         detection: java_spring_sqli_dynamic_input
+        scope: result
 auxiliary:
+  - id: java_spring_sqli_jdbc_template
+    patterns:
+      - pattern: $<JDBC_TEMPLATE_INSTANCE>;
+        filters:
+          - variable: JDBC_TEMPLATE_INSTANCE
+            detection: java_shared_lang_instance
+            scope: cursor
+            filters:
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(org\.springframework\.jdbc\.core\.)?JdbcTemplate\z
+      # fallback
+      - jdbcTemplate;
   - id: java_spring_sqli_dynamic_input
     patterns:
       - pattern: |
@@ -27,11 +67,11 @@ auxiliary:
         filters:
           - variable: STRING_LITERAL
             detection: string_literal
-            contains: false
+            scope: cursor
           - not:
               variable: DYNAMIC_INPUT
               detection: string_literal
-              contains: false
+              scope: cursor
 languages:
   - java
 trigger:

--- a/java/spring/sqli/.snapshots/string_concatenation.yml
+++ b/java/spring/sqli/.snapshots/string_concatenation.yml
@@ -42,26 +42,221 @@ low:
             - [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
             - [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
         documentation_url: https://docs.bearer.com/reference/rules/java_spring_sqli
-      line_number: 6
+      line_number: 14
       full_filename: /tmp/scan/string_concatenation.java
       filename: .
       source:
         location:
-            start: 6
-            end: 6
+            start: 14
+            end: 14
+            column:
+                start: 21
+                end: 83
+      sink:
+        location:
+            start: 14
+            end: 14
+            column:
+                start: 21
+                end: 83
+        content: new PreparedStatementCreatorFactory(myQueryStr, Types.VARCHAR)
+      parent_line_number: 14
+      snippet: new PreparedStatementCreatorFactory(myQueryStr, Types.VARCHAR)
+      fingerprint: ebf8b9a53c73eabed841989514b90054_0
+      old_fingerprint: b6b432ac3b8b51ea957f2fed2a2732ae_0
+    - rule:
+        cwe_ids:
+            - "89"
+        id: java_spring_sqli
+        title: Unsanitized user input in SQL query detected.
+        description: |
+            ## Description
+
+            Including unsanitized data, such as user input or request data, in raw SQL
+            queries makes your application vulnerable to SQL injection attacks.
+
+            ## Remediations
+
+            ❌ Avoid raw queries, especially those that contain unsanitized user input:
+
+            ```java
+              String query = "update user set name='"+uri.getQueryParameter("name")+"' where id='"+uri.getQueryParameter("userId")+"'";
+              return jdbcTemplate.update(query);
+            ```
+
+            ✅ Use `PreparedStatement` creators and setters to construct SQL queries
+
+            ```java
+            new PreparedStatementCreator() {
+              public PreparedStatement createPreparedStatement(Connection conn) throws SQLException {
+                String updateString = "update user set name = ? where id = ?";
+                return conn.prepareStatement(updateString);
+              }
+            }
+
+            new PreparedStatementSetter() {
+              public void setValues(PreparedStatement preparedStatement) throws SQLException {
+                preparedStatement.setString(1, uri.getQueryParameter("name"))
+                preparedStatement.setInt(2, uri.getQueryParameter("userId"))
+              }
+            }
+            ```
+
+            ## Resources
+            - [JDBC Template class](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/core/JdbcTemplate.html)
+            - [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+            - [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/java_spring_sqli
+      line_number: 15
+      full_filename: /tmp/scan/string_concatenation.java
+      filename: .
+      source:
+        location:
+            start: 15
+            end: 15
+            column:
+                start: 7
+                end: 58
+      sink:
+        location:
+            start: 15
+            end: 15
+            column:
+                start: 7
+                end: 58
+        content: factory.newPreparedStatementCreator(myQueryStr, [])
+      parent_line_number: 15
+      snippet: factory.newPreparedStatementCreator(myQueryStr, [])
+      fingerprint: ebf8b9a53c73eabed841989514b90054_1
+      old_fingerprint: b6b432ac3b8b51ea957f2fed2a2732ae_1
+    - rule:
+        cwe_ids:
+            - "89"
+        id: java_spring_sqli
+        title: Unsanitized user input in SQL query detected.
+        description: |
+            ## Description
+
+            Including unsanitized data, such as user input or request data, in raw SQL
+            queries makes your application vulnerable to SQL injection attacks.
+
+            ## Remediations
+
+            ❌ Avoid raw queries, especially those that contain unsanitized user input:
+
+            ```java
+              String query = "update user set name='"+uri.getQueryParameter("name")+"' where id='"+uri.getQueryParameter("userId")+"'";
+              return jdbcTemplate.update(query);
+            ```
+
+            ✅ Use `PreparedStatement` creators and setters to construct SQL queries
+
+            ```java
+            new PreparedStatementCreator() {
+              public PreparedStatement createPreparedStatement(Connection conn) throws SQLException {
+                String updateString = "update user set name = ? where id = ?";
+                return conn.prepareStatement(updateString);
+              }
+            }
+
+            new PreparedStatementSetter() {
+              public void setValues(PreparedStatement preparedStatement) throws SQLException {
+                preparedStatement.setString(1, uri.getQueryParameter("name"))
+                preparedStatement.setInt(2, uri.getQueryParameter("userId"))
+              }
+            }
+            ```
+
+            ## Resources
+            - [JDBC Template class](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/core/JdbcTemplate.html)
+            - [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+            - [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/java_spring_sqli
+      line_number: 17
+      full_filename: /tmp/scan/string_concatenation.java
+      filename: .
+      source:
+        location:
+            start: 17
+            end: 17
             column:
                 start: 7
                 end: 38
       sink:
         location:
-            start: 6
-            end: 6
+            start: 17
+            end: 17
             column:
                 start: 7
                 end: 38
-        content: JdbcTemplate.update(myQueryStr)
-      parent_line_number: 6
-      snippet: JdbcTemplate.update(myQueryStr)
-      fingerprint: ebf8b9a53c73eabed841989514b90054_0
-      old_fingerprint: b6b432ac3b8b51ea957f2fed2a2732ae_0
+        content: t.batchUpdate("ok", myQueryStr)
+      parent_line_number: 17
+      snippet: t.batchUpdate("ok", myQueryStr)
+      fingerprint: ebf8b9a53c73eabed841989514b90054_2
+      old_fingerprint: b6b432ac3b8b51ea957f2fed2a2732ae_2
+    - rule:
+        cwe_ids:
+            - "89"
+        id: java_spring_sqli
+        title: Unsanitized user input in SQL query detected.
+        description: |
+            ## Description
+
+            Including unsanitized data, such as user input or request data, in raw SQL
+            queries makes your application vulnerable to SQL injection attacks.
+
+            ## Remediations
+
+            ❌ Avoid raw queries, especially those that contain unsanitized user input:
+
+            ```java
+              String query = "update user set name='"+uri.getQueryParameter("name")+"' where id='"+uri.getQueryParameter("userId")+"'";
+              return jdbcTemplate.update(query);
+            ```
+
+            ✅ Use `PreparedStatement` creators and setters to construct SQL queries
+
+            ```java
+            new PreparedStatementCreator() {
+              public PreparedStatement createPreparedStatement(Connection conn) throws SQLException {
+                String updateString = "update user set name = ? where id = ?";
+                return conn.prepareStatement(updateString);
+              }
+            }
+
+            new PreparedStatementSetter() {
+              public void setValues(PreparedStatement preparedStatement) throws SQLException {
+                preparedStatement.setString(1, uri.getQueryParameter("name"))
+                preparedStatement.setInt(2, uri.getQueryParameter("userId"))
+              }
+            }
+            ```
+
+            ## Resources
+            - [JDBC Template class](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/jdbc/core/JdbcTemplate.html)
+            - [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)
+            - [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)
+        documentation_url: https://docs.bearer.com/reference/rules/java_spring_sqli
+      line_number: 18
+      full_filename: /tmp/scan/string_concatenation.java
+      filename: .
+      source:
+        location:
+            start: 18
+            end: 18
+            column:
+                start: 7
+                end: 28
+      sink:
+        location:
+            start: 18
+            end: 18
+            column:
+                start: 7
+                end: 28
+        content: t.execute(myQueryStr)
+      parent_line_number: 18
+      snippet: t.execute(myQueryStr)
+      fingerprint: ebf8b9a53c73eabed841989514b90054_3
+      old_fingerprint: b6b432ac3b8b51ea957f2fed2a2732ae_3
 

--- a/java/spring/sqli/testdata/safe.java
+++ b/java/spring/sqli/testdata/safe.java
@@ -1,6 +1,9 @@
 import org.springframework.jdbc.core;
 
 public class Foo {
+   @Autowired
+   JdbcTemplate t;
+
    public Bar updateUser(final String name, final Int id) {
       JdbcTemplate.update(new PreparedStatementCreator() {
          public PreparedStatement createPreparedStatement(final Connection conn) throws SQLException {
@@ -10,5 +13,11 @@ public class Foo {
             return myQuery;
          }
       });
+
+      var factory = new PreparedStatementCreatorFactory("ok", Types.VARCHAR);
+      factory.newPreparedStatementCreator("ok", []);
+
+      t.batchUpdate("ok", "ok");
+      t.execute("ok");
    }
 }

--- a/java/spring/sqli/testdata/string_concatenation.java
+++ b/java/spring/sqli/testdata/string_concatenation.java
@@ -1,8 +1,20 @@
-import org.springframework.jdbc.core;
+package com.example.sqli;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementCreatorFactory;
 
 public class Foo {
-   public Bar updateUser(HttpServletRequest request, HttpServletResponse response) {
+   @Autowired
+   JdbcTemplate t;
+
+   public void updateUser() {
       String myQueryStr = "update user set name='"+request.getParameter("name")+"' where id='"+request.getParameter("userId")+"'";
-      JdbcTemplate.update(myQueryStr);
+
+      var factory = new PreparedStatementCreatorFactory(myQueryStr, Types.VARCHAR);
+      factory.newPreparedStatementCreator(myQueryStr, []);
+
+      t.batchUpdate("ok", myQueryStr);
+      t.execute(myQueryStr);
    }
 }


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Makes the Java SQL injection rules stricter about the types they match. 

The patterns are currently quite generic (eg. `execute`) which causes a lot of false positives with non-database code.

## Related
- Closes #80 


## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
