### PR TITLE
fix(java): typo in information leak rule

### DIFF
--- a/java/lang/information_leakage.yml
+++ b/java/lang/information_leakage.yml
@@ -14,21 +14,21 @@ patterns:
               - Error
               - OutOfMemoryError
               - StackOverflowError
-          - variable: ERROR
+          - variable: EXCEPTION
             regex: \A(java\.io\.)?FileNotFoundException\z
-          - variable: ERROR
+          - variable: EXCEPTION
             regex: \A(java\.sql\.)?SQLException\z
-          - variable: ERROR
+          - variable: EXCEPTION
             regex: \A(java\.net\.)?BindException\z
-          - variable: ERROR
+          - variable: EXCEPTION
             regex: \A(java\.util\.)?ConcurrentModificationException\z
-          - variable: ERROR
+          - variable: EXCEPTION
             regex: \A(javax\.naming\.)?InsufficientResourcesException\z
-          - variable: ERROR
+          - variable: EXCEPTION
             regex: \A(java\.util\.)?MissingResourceException\z
-          - variable: ERROR
+          - variable: EXCEPTION
             regex: \A(java\.util\.jar\.)?JarException\z
-          - variable: ERROR
+          - variable: EXCEPTION
             regex: \A(java\.security\.acl\.)?NotOwnerException\z
 languages:
   - java


### PR DESCRIPTION
## Description
Replace `ERROR` with `EXCEPTION` in rule pattern

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
