### PR TITLE
fix(java): file permission others rule

### DIFF
--- a/java/lang/file_permission_others.yml
+++ b/java/lang/file_permission_others.yml
@@ -1,9 +1,5 @@
 patterns:
-  - pattern: |
-      {
-        $<!>$<PERMISSIONS>.add($<OTHER_PERMISSION>);
-        Files.setPosixFilePermissions($<_>, $<PERMISSIONS>);
-      }
+  - pattern: $<PERMISSIONS>.add($<OTHER_PERMISSION>);
     filters:
       - variable: PERMISSIONS
         detection: java_lang_get_posix_file_permissions

--- a/java/lang/file_permission_others/.snapshots/others.yml
+++ b/java/lang/file_permission_others/.snapshots/others.yml
@@ -30,17 +30,17 @@ warning:
             end: 3
             column:
                 start: 3
-                end: 52
+                end: 51
       sink:
         location:
             start: 3
             end: 3
             column:
                 start: 3
-                end: 52
-        content: permissions.add(PosixFilePermission.OTHER_WRITE);
+                end: 51
+        content: permissions.add(PosixFilePermission.OTHER_WRITE)
       parent_line_number: 3
-      snippet: permissions.add(PosixFilePermission.OTHER_WRITE);
+      snippet: permissions.add(PosixFilePermission.OTHER_WRITE)
       fingerprint: 12e9ca5557a4ca260d8f219fc77d4d18_0
       old_fingerprint: c8f96e6f068df6d65e3655a850082e33_0
 


### PR DESCRIPTION
## Description
Remove requirement for `setPosixFilePermissions` from Java file permission rule pattern

We were missing nested cases of the `setPosixFilePermissions` call (similar issue to https://github.com/Bearer/bearer-rules/issues/122) but on reflection, with this rule, the bad part is adding the OTHERS permission rather than the `setPosixFilePermissions` call itself, so we simplify the rule pattern. 

Severity level remains at WARNING

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
