### PR TITLE
feat(java): match more cases in info leakage rule

### DIFF
--- a/java/lang/information_leakage.yml
+++ b/java/lang/information_leakage.yml
@@ -1,35 +1,39 @@
+imports:
+  - java_shared_lang_instance
 patterns:
-  - pattern: |
-      try {
-        $<...>
-      } catch($<EXCEPTION> $<EXCEPTION_VAR:identifier>) {
-        $<!>$<EXCEPTION_VAR>.printStackTrace();
-      }
+  - pattern: $<EXCEPTION>.printStackTrace();
     filters:
-      - either:
-          - variable: EXCEPTION
-            values:
-              - Throwable
-              - Exception
-              - Error
-              - OutOfMemoryError
-              - StackOverflowError
-          - variable: EXCEPTION
-            regex: \A(java\.io\.)?FileNotFoundException\z
-          - variable: EXCEPTION
-            regex: \A(java\.sql\.)?SQLException\z
-          - variable: EXCEPTION
-            regex: \A(java\.net\.)?BindException\z
-          - variable: EXCEPTION
-            regex: \A(java\.util\.)?ConcurrentModificationException\z
-          - variable: EXCEPTION
-            regex: \A(javax\.naming\.)?InsufficientResourcesException\z
-          - variable: EXCEPTION
-            regex: \A(java\.util\.)?MissingResourceException\z
-          - variable: EXCEPTION
-            regex: \A(java\.util\.jar\.)?JarException\z
-          - variable: EXCEPTION
-            regex: \A(java\.security\.acl\.)?NotOwnerException\z
+      - variable: EXCEPTION
+        detection: java_shared_lang_instance
+        scope: cursor
+        filters:
+          - either:
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.lang\.)?Throwable\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.lang\.)?Error\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.lang\.)?Exception\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.lang\.)?OutOfMemoryError\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.lang\.)?StackOverflowError\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.io\.)?FileNotFoundException\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.sql\.)?SQLException\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.net\.)?BindException\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.util\.)?ConcurrentModificationException\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(javax\.naming\.)?InsufficientResourcesException\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.util\.)?MissingResourceException\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.util\.jar\.)?JarException\z
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.security\.acl\.)?NotOwnerException\z
 languages:
   - java
 severity: warning

--- a/java/lang/information_leakage/.snapshots/leak.yml
+++ b/java/lang/information_leakage/.snapshots/leak.yml
@@ -28,17 +28,17 @@ warning:
             end: 8
             column:
                 start: 7
-                end: 27
+                end: 26
       sink:
         location:
             start: 8
             end: 8
             column:
                 start: 7
-                end: 27
-        content: e.printStackTrace();
+                end: 26
+        content: e.printStackTrace()
       parent_line_number: 8
-      snippet: e.printStackTrace();
+      snippet: e.printStackTrace()
       fingerprint: 9fff3d7f302686a23685fc6d2a7ac46c_0
       old_fingerprint: ed4d9e002c9d28c2a3f4a53209ee125b_0
 

--- a/java/lang/information_leakage/testdata/ok.java
+++ b/java/lang/information_leakage/testdata/ok.java
@@ -3,7 +3,7 @@ public class Main {
     try {
       // something risky!
     } catch (Exception e) {
-      System.out.println("Oops!")
+      System.out.println("Oops!");
     }
   }
 }

--- a/java/lang/trust_boundary_violation/.snapshots/bad.yml
+++ b/java/lang/trust_boundary_violation/.snapshots/bad.yml
@@ -319,17 +319,17 @@ warning:
             end: 35
             column:
                 start: 7
-                end: 36
+                end: 46
       sink:
         location:
             start: 35
             end: 35
             column:
                 start: 7
-                end: 36
-        content: e.setAttribute(KEY, getFoo())
+                end: 46
+        content: caughtError.setAttribute(KEY, getFoo())
       parent_line_number: 35
-      snippet: e.setAttribute(KEY, getFoo())
+      snippet: caughtError.setAttribute(KEY, getFoo())
       fingerprint: 0011f9ce80042a297b7ed3b3edbcf26a_8
       old_fingerprint: 2bfea37963fd4ad9955ed90333a00976_8
     - rule:
@@ -347,26 +347,26 @@ warning:
 
             ✅ Avoid adding trusted data to data structures containing untrusted data
         documentation_url: https://docs.bearer.com/reference/rules/java_lang_trust_boundary_violation
-      line_number: 39
+      line_number: 41
       full_filename: /tmp/scan/bad.java
       filename: .
       source:
         location:
-            start: 39
-            end: 39
+            start: 41
+            end: 41
             column:
                 start: 7
-                end: 43
+                end: 54
       sink:
         location:
-            start: 39
-            end: 39
+            start: 41
+            end: 41
             column:
                 start: 7
-                end: 43
-        content: resource.setAttribute(KEY, getFoo())
-      parent_line_number: 39
-      snippet: resource.setAttribute(KEY, getFoo())
+                end: 54
+        content: caughtResourceError.setAttribute(KEY, getFoo())
+      parent_line_number: 41
+      snippet: caughtResourceError.setAttribute(KEY, getFoo())
       fingerprint: 0011f9ce80042a297b7ed3b3edbcf26a_9
       old_fingerprint: 2bfea37963fd4ad9955ed90333a00976_9
     - rule:
@@ -384,26 +384,63 @@ warning:
 
             ✅ Avoid adding trusted data to data structures containing untrusted data
         documentation_url: https://docs.bearer.com/reference/rules/java_lang_trust_boundary_violation
-      line_number: 43
+      line_number: 45
       full_filename: /tmp/scan/bad.java
       filename: .
       source:
         location:
-            start: 43
-            end: 43
+            start: 45
+            end: 45
+            column:
+                start: 7
+                end: 43
+      sink:
+        location:
+            start: 45
+            end: 45
+            column:
+                start: 7
+                end: 43
+        content: resource.setAttribute(KEY, getFoo())
+      parent_line_number: 45
+      snippet: resource.setAttribute(KEY, getFoo())
+      fingerprint: 0011f9ce80042a297b7ed3b3edbcf26a_10
+      old_fingerprint: 2bfea37963fd4ad9955ed90333a00976_10
+    - rule:
+        cwe_ids:
+            - "501"
+        id: java_lang_trust_boundary_violation
+        title: Trust boundary violation detected.
+        description: |
+            ## Description
+
+            Mixing trusted and untrusted data inside the same data structure can lead
+            to untrusted data being mistakenly treated as being trusted.
+
+            ## Remediations
+
+            ✅ Avoid adding trusted data to data structures containing untrusted data
+        documentation_url: https://docs.bearer.com/reference/rules/java_lang_trust_boundary_violation
+      line_number: 49
+      full_filename: /tmp/scan/bad.java
+      filename: .
+      source:
+        location:
+            start: 49
+            end: 49
             column:
                 start: 7
                 end: 42
       sink:
         location:
-            start: 43
-            end: 43
+            start: 49
+            end: 49
             column:
                 start: 7
                 end: 42
         content: forEach.setAttribute(KEY, getFoo())
-      parent_line_number: 43
+      parent_line_number: 49
       snippet: forEach.setAttribute(KEY, getFoo())
-      fingerprint: 0011f9ce80042a297b7ed3b3edbcf26a_10
-      old_fingerprint: 2bfea37963fd4ad9955ed90333a00976_10
+      fingerprint: 0011f9ce80042a297b7ed3b3edbcf26a_11
+      old_fingerprint: 2bfea37963fd4ad9955ed90333a00976_11
 

--- a/java/lang/trust_boundary_violation/testdata/bad.java
+++ b/java/lang/trust_boundary_violation/testdata/bad.java
@@ -31,8 +31,14 @@ public class Main {
       x.foo();
     } catch (SomeException e) {
       foo;
-    } catch (OtherException|HttpServletRequest e) {
-      e.setAttribute(KEY, getFoo());
+    } catch (OtherException|HttpServletRequest caughtError) {
+      caughtError.setAttribute(KEY, getFoo());
+    }
+
+    try (Something abc = getBar()) {
+      abc.foo();
+    } catch (HttpServletRequest caughtResourceError) {
+      caughtResourceError.setAttribute(KEY, getFoo());
     }
 
     try (ServletRequest resource = getReq()) {

--- a/java/shared/lang/instance.yml
+++ b/java/shared/lang/instance.yml
@@ -25,6 +25,9 @@ patterns:
   # exception handler
   - pattern: try {} catch($<JAVA_SHARED_LANG_INSTANCE_TYPE> $<JAVA_SHARED_LANG_INSTANCE_VARIABLE>) {}
     focus: JAVA_SHARED_LANG_INSTANCE_VARIABLE
+  # exception handler on resource block
+  - pattern: try ($<_>$<...>) {} catch($<JAVA_SHARED_LANG_INSTANCE_TYPE> $<JAVA_SHARED_LANG_INSTANCE_VARIABLE>) {}
+    focus: JAVA_SHARED_LANG_INSTANCE_VARIABLE
   # resource block
   - pattern: try ($<JAVA_SHARED_LANG_INSTANCE_TYPE> $<JAVA_SHARED_LANG_INSTANCE_VARIABLE> = $<_>) {}
     focus: JAVA_SHARED_LANG_INSTANCE_VARIABLE


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Support exception handlers on resource blocks in Java shared instance rule, and use the shared rule in the information leakage rule.

## Related
- Close https://github.com/Bearer/bearer-rules/issues/122
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [x] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
