### PR TITLE
docs: duplicate titles for JS Express rules

### DIFF
--- a/javascript/express/helmet_missing.yml
+++ b/javascript/express/helmet_missing.yml
@@ -86,7 +86,7 @@ trigger:
   match_on: absence
   required_detection: javascript_express_helmet_missing_express_init
 metadata:
-  description: "Security misconfiguration detected."
+  description: "Security misconfiguration detected (Helmet missing)."
   remediation_message: |
     ## Description
 

--- a/javascript/express/helmet_missing/.snapshots/insecure.yml
+++ b/javascript/express/helmet_missing/.snapshots/insecure.yml
@@ -3,7 +3,7 @@ low:
         cwe_ids:
             - "693"
         id: javascript_express_helmet_missing
-        title: Security misconfiguration detected.
+        title: Security misconfiguration detected (Helmet missing).
         description: |
             ## Description
 

--- a/javascript/express/reduce_fingerprint.yml
+++ b/javascript/express/reduce_fingerprint.yml
@@ -23,7 +23,7 @@ trigger:
   match_on: absence
   required_detection: javascript_express_reduce_fingerprint_express_init
 metadata:
-  description: "Security misconfiguration detected."
+  description: "Security misconfiguration detected (server fingerprinting)."
   remediation_message: |
     ## Description
 

--- a/javascript/express/reduce_fingerprint/.snapshots/insecure.yml
+++ b/javascript/express/reduce_fingerprint/.snapshots/insecure.yml
@@ -3,7 +3,7 @@ low:
         cwe_ids:
             - "693"
         id: javascript_express_reduce_fingerprint
-        title: Security misconfiguration detected.
+        title: Security misconfiguration detected (server fingerprinting).
         description: |
             ## Description
 


### PR DESCRIPTION
## Description
Fix duplicate titles for JS Express rules for Helmet and server fingerprinting security configurations. 

Both show up as `"LOW: Security misconfiguration detected. [CWE-693]"` in the report and this is pretty confusing. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
