### PR TITLE
fix: Java Random rule pattern

### DIFF
--- a/rules/java/lang/insufficiently_random_values.yml
+++ b/rules/java/lang/insufficiently_random_values.yml
@@ -2,18 +2,11 @@ imports:
   - java_shared_lang_instance
 patterns:
   - pattern: |
-      $<RANDOM>.$<METHOD>();
+      new $<RANDOM>();
     filters:
       - variable: RANDOM
-        detection: java_shared_lang_instance
+        regex: \A(java\.util\.)?Random\z
         scope: cursor
-        filters:
-          - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
-            regex: \A(java\.util\.)?Random\z
-      - not:
-          variable: METHOD
-          values:
-            - setSeed
   - pattern: $<TYPE>.random();
     filters:
       - variable: TYPE

--- a/tests/java/lang/insufficiently_random_values/__snapshots__/test.js.snap
+++ b/tests/java/lang/insufficiently_random_values/__snapshots__/test.js.snap
@@ -35,7 +35,7 @@ exports[`java_lang_insufficiently_random_values bad 1`] = `
       "snippet": "new Random()",
       "fingerprint": "8f51671abbce2a871cc191dc35531c9f_0",
       "old_fingerprint": "32a0cd15fe8bb40ad4a1cfb2d4b4da96_0",
-      "code_extract": "rand.next();"
+      "code_extract": "Random rand = new Random();"
     },
     {
       "cwe_ids": [

--- a/tests/java/lang/insufficiently_random_values/__snapshots__/test.js.snap
+++ b/tests/java/lang/insufficiently_random_values/__snapshots__/test.js.snap
@@ -11,28 +11,28 @@ exports[`java_lang_insufficiently_random_values bad 1`] = `
       "title": "Insufficiently random value detected.",
       "description": "## Description\\n\\nUsing predictable random values makes our application vulnerable to attacks,\\nespecially if these values are used for security purposes.\\n\\n## Remediations\\n\\n✅ Use a stronger library when generating random values\\n\\n\`\`\`java\\nSecureRandom random = new SecureRandom();\\n\`\`\`\\n\\n## Resources\\n- [Java SecureRandom class](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/security/SecureRandom.html)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/java_lang_insufficiently_random_values",
-      "line_number": 2,
+      "line_number": 1,
       "full_filename": "/tmp/bearer-scan/bad.java",
       "filename": ".",
       "source": {
-        "start": 2,
-        "end": 2,
+        "start": 1,
+        "end": 1,
         "column": {
-          "start": 1,
-          "end": 12
+          "start": 15,
+          "end": 27
         }
       },
       "sink": {
-        "start": 2,
-        "end": 2,
+        "start": 1,
+        "end": 1,
         "column": {
-          "start": 1,
-          "end": 12
+          "start": 15,
+          "end": 27
         },
-        "content": "rand.next()"
+        "content": "new Random()"
       },
-      "parent_line_number": 2,
-      "snippet": "rand.next()",
+      "parent_line_number": 1,
+      "snippet": "new Random()",
       "fingerprint": "8f51671abbce2a871cc191dc35531c9f_0",
       "old_fingerprint": "32a0cd15fe8bb40ad4a1cfb2d4b4da96_0",
       "code_extract": "rand.next();"

--- a/tests/java/lang/insufficiently_random_values/testdata/ok_secure_random.java
+++ b/tests/java/lang/insufficiently_random_values/testdata/ok_secure_random.java
@@ -10,10 +10,19 @@ public class Main
 		byte[] randomBytes = new byte[128];
 		secureRandomGenerator.nextBytes(randomBytes);
 
-		//Get random integer
+		// Get random integer
 		int r = secureRandomGenerator.nextInt();
 
-		//Get random integer in range
+		// Get random integer in range
 		int randInRange = secureRandomGenerator.nextInt(999999);
+
+		// sneaky example
+		java.util.Random numGen = java.security.SecureRandom.getInstance("SHA1PRNG");
+    double rand = getNextNumber(numGen);
+    String key = Double.toString(rand).substring(2);
 	}
+
+  double getNextNumber(java.util.Random generator) {
+    return generator.nextDouble();
+  }
 }


### PR DESCRIPTION
## Description

Since Java's `SecureRandom` is an instance of `Random`, our rule can have false positives in the example below

```java
public class Foo {
  public void main() {
    java.util.Random numGen = java.security.SecureRandom.getInstance("SHA1PRNG");
    double rand = getNextNumber(numGen);
    String key = Double.toString(rand).substring(2);
  }

  double getNextNumber(java.util.Random generator) {
    return generator.nextDouble(); // <- this is fine when SecureRandom is passed to this function (as above)
  }
}
```

A possible fix is to catch on instantiation (i.e. `Random.new`) instead of method calls. Open to other more sophisticated solutions. 

<!-- Add this section if required
## Related
-->
Closes [#115](https://github.com/Bearer/bearer-rules/issues/115)
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
