### PR TITLE
fix: improve sanitizer for react inner html

### DIFF
--- a/rules/javascript/react/dangerously_set_inner_html.yml
+++ b/rules/javascript/react/dangerously_set_inner_html.yml
@@ -18,6 +18,7 @@ auxiliary:
       - $<_>.sanitize($<_>)
       - sanitize($<_>)
       - sanitizeHTML($<_>)
+      - sanitizeHtml($<_>)
       - renderMarkdown($<_>)
 languages:
   - javascript

--- a/rules/javascript/react/dangerously_set_inner_html.yml
+++ b/rules/javascript/react/dangerously_set_inner_html.yml
@@ -4,10 +4,10 @@ patterns:
     filters:
       - not:
           variable: DATA
-          detection: javascript_react_dangerously_set_inner_html_sanitzed_input
+          detection: javascript_react_dangerously_set_inner_html_sanitized_input
           scope: result
 auxiliary:
-  - id: javascript_react_dangerously_set_inner_html_sanitzed_input
+  - id: javascript_react_dangerously_set_inner_html_sanitized_input
     patterns:
       - pattern: |
           $<STRING_LITERAL>
@@ -15,6 +15,7 @@ auxiliary:
           - variable: STRING_LITERAL
             detection: string_literal
             scope: cursor
+      - $<_>.sanitize($<_>)
       - sanitize($<_>)
       - sanitizeHTML($<_>)
       - renderMarkdown($<_>)

--- a/rules/javascript/shared/third_parties/sanitize_html_sanitizer.yml
+++ b/rules/javascript/shared/third_parties/sanitize_html_sanitizer.yml
@@ -2,9 +2,11 @@ type: shared
 languages:
   - javascript
 patterns:
+  # sanitize-html
   - $<_>.sanitize($<!>$<_>$<...>)
   - sanitize($<!>$<_>$<...>)
+  # DOMPurifier
   - sanitizeHtml($<!>$<_>$<...>)
 metadata:
-  description: "sanitize-html HTML sanitizer."
+  description: "sanitize HTML sanitizer."
   id: javascript_shared_third_parties_sanitize_html_sanitizer

--- a/rules/javascript/shared/third_parties/sanitize_html_sanitizer.yml
+++ b/rules/javascript/shared/third_parties/sanitize_html_sanitizer.yml
@@ -2,6 +2,8 @@ type: shared
 languages:
   - javascript
 patterns:
+  - $<_>.sanitize($<!>$<_>$<...>)
+  - sanitize($<!>$<_>$<...>)
   - sanitizeHtml($<!>$<_>$<...>)
 metadata:
   description: "sanitize-html HTML sanitizer."

--- a/tests/javascript/lang/dangerous_insert_html/testdata/secure.js
+++ b/tests/javascript/lang/dangerous_insert_html/testdata/secure.js
@@ -10,3 +10,7 @@ function ok2() {
 function ok3(userInput) {
   document.innerHTML = "<div>" + sanitizeHtml(userInput) + "</div>"
 }
+
+function ok4(userInput) {
+  document.innerHTML = "<div>" + sanitize(userInput) + "</div>"
+}

--- a/tests/javascript/react/dangerously_set_inner_html/__snapshots__/test.js.snap
+++ b/tests/javascript/react/dangerously_set_inner_html/__snapshots__/test.js.snap
@@ -82,6 +82,8 @@ exports[`javascript_react_dangerously_set_inner_html insecure-template_string 1`
 }"
 `;
 
+exports[`javascript_react_dangerously_set_inner_html secure-dom-purify 1`] = `"{}"`;
+
 exports[`javascript_react_dangerously_set_inner_html secure-render-markdown 1`] = `"{}"`;
 
 exports[`javascript_react_dangerously_set_inner_html secure-sanitize 1`] = `"{}"`;

--- a/tests/javascript/react/dangerously_set_inner_html/test.js
+++ b/tests/javascript/react/dangerously_set_inner_html/test.js
@@ -3,35 +3,34 @@ const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
 
 describe(ruleId, () => {
   const invoke = createInvoker(ruleId, ruleFile, testBase)
-  
 
   test("insecure-raw_input", () => {
     const testCase = "insecure-raw_input.js"
-    expect(invoke(testCase)).toMatchSnapshot();
+    expect(invoke(testCase)).toMatchSnapshot()
   })
-  
 
   test("insecure-template_string", () => {
     const testCase = "insecure-template_string.js"
-    expect(invoke(testCase)).toMatchSnapshot();
+    expect(invoke(testCase)).toMatchSnapshot()
   })
-  
 
   test("secure-render-markdown", () => {
     const testCase = "secure-render-markdown.js"
-    expect(invoke(testCase)).toMatchSnapshot();
+    expect(invoke(testCase)).toMatchSnapshot()
   })
-  
 
   test("secure-sanitize", () => {
     const testCase = "secure-sanitize.js"
-    expect(invoke(testCase)).toMatchSnapshot();
+    expect(invoke(testCase)).toMatchSnapshot()
   })
-  
 
   test("secure-template_string", () => {
     const testCase = "secure-template_string.js"
-    expect(invoke(testCase)).toMatchSnapshot();
+    expect(invoke(testCase)).toMatchSnapshot()
   })
-  
+
+  test("secure-dom-purify", () => {
+    const testCase = "secure-dom_purify.tsx"
+    expect(invoke(testCase)).toMatchSnapshot()
+  })
 })

--- a/tests/javascript/react/dangerously_set_inner_html/testdata/secure-dom_purify.tsx
+++ b/tests/javascript/react/dangerously_set_inner_html/testdata/secure-dom_purify.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import * as DOMPurify from 'dompurify';
+
+interface Props {
+  htmlContent: string;
+}
+
+const InsecureComponent: React.FC<Props> = ({ htmlContent }) => {
+  return (
+    <div dangerouslySetInnerHTML={{
+			__html: DOMPurify.sanitize(htmlContent)
+		}} />
+  );
+};
+
+export default InsecureComponent;


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

We were classifying React Inner HTML incorrectly when `DOMPurify` was used to sanitize the input

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
