### PR TITLE
test: update snapshots for latest cli

### DIFF
--- a/tests/java/lang/os_command_injection/__snapshots__/test.js.snap
+++ b/tests/java/lang/os_command_injection/__snapshots__/test.js.snap
@@ -104,6 +104,40 @@ exports[`java_lang_os_command_injection bad 1`] = `
       "fingerprint": "5665fcfd14328e5c667ee31b32dffafd_2",
       "old_fingerprint": "a0ce9f3043b13a6baf7c16fd7608b765_2",
       "code_extract": "        ProcessBuilder pb = new ProcessBuilder(\\"sh -c echo \\" + name);"
+    },
+    {
+      "cwe_ids": [
+        "78"
+      ],
+      "id": "java_lang_os_command_injection",
+      "title": "Command injection vulnerability detected.",
+      "description": "## Description\\n\\nUsing external or user-defined input directly in an OS command can allow attackers to perform dangerous commands on the operating system.\\n\\n## Remediations\\n\\n❌ Avoid using OS commands, with or without dynamic input, wherever possible. For example, look for an equivalent library or function to use instead.\\n\\n✅ For dynamic input, rely on hardcoded values wherever possible\\n\\n\`\`\`java\\n  String filePattern = \\"*.json\\";\\n  if request.getParameter(\\"format\\") == \\"xml\\" {\\n    filePattern = \\"*.xml\\"\\n  }\\n\\n  Process process = Runtime.getRuntime().exec(\\"ls /myDir/\\" + extension);\\n\`\`\`\\n\\n## Resources\\n- [OWASP command injection explained](https://owasp.org/www-community/attacks/Command_Injection)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/java_lang_os_command_injection",
+      "line_number": 21,
+      "full_filename": "/tmp/bearer-scan/bad.java",
+      "filename": ".",
+      "source": {
+        "start": 21,
+        "end": 21,
+        "column": {
+          "start": 9,
+          "end": 41
+        }
+      },
+      "sink": {
+        "start": 21,
+        "end": 21,
+        "column": {
+          "start": 9,
+          "end": 41
+        },
+        "content": "pb.command(\\"sh -c echo \\" + name)"
+      },
+      "parent_line_number": 21,
+      "snippet": "pb.command(\\"sh -c echo \\" + name)",
+      "fingerprint": "5665fcfd14328e5c667ee31b32dffafd_3",
+      "old_fingerprint": "a0ce9f3043b13a6baf7c16fd7608b765_3",
+      "code_extract": "        pb.command(\\"sh -c echo \\" + name);"
     }
   ]
 }"

--- a/tests/java/lang/sqli/__snapshots__/test.js.snap
+++ b/tests/java/lang/sqli/__snapshots__/test.js.snap
@@ -104,6 +104,108 @@ exports[`java_lang_sqli bad 1`] = `
       "fingerprint": "79d5d495c5c408c582b32582f1ae9171_2",
       "old_fingerprint": "db6f664c606e5cc7e0b287583ab73e93_2",
       "code_extract": "      emf.createEntityManager().createQuery(sqlQuery);"
+    },
+    {
+      "cwe_ids": [
+        "89"
+      ],
+      "id": "java_lang_sqli",
+      "title": "Unsanitized user input in SQL query detected.",
+      "description": "## Description\\n\\nIncluding unsanitized data, such as user input or request data, in raw SQL\\nqueries makes your application vulnerable to SQL injection attacks.\\n\\n## Remediations\\n\\n❌ Avoid raw queries, especially those that contain unsanitized user input:\\n\\n\`\`\`java\\n  Statement stmt = conn.createStatement();\\n  ResultSet rs = stmt.executeQuery(\\"select name from users where id='\\"+ uri.getQueryParameter(\\"user_id\\") \\"'\\")) {\\n\`\`\`\\n\\n✅ Instead of using dynamically crafted strings for your SQL queries, use prepared statements instead\\n\\n\`\`\`java\\nmyStmt = myCon.prepareStatement(\\"select * from students where age > ? and name = ?\\");\\nmyStmt.setInt(1, uri.getQueryParameter(\\"age\\"));\\nmyStmt.setString(2, uri.getQueryParameter(\\"name\\"));\\n\`\`\`\\n\\n## Resources\\n- [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)\\n- [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/java_lang_sqli",
+      "line_number": 36,
+      "full_filename": "/tmp/bearer-scan/bad.java",
+      "filename": ".",
+      "source": {
+        "start": 36,
+        "end": 36,
+        "column": {
+          "start": 7,
+          "end": 65
+        }
+      },
+      "sink": {
+        "start": 36,
+        "end": 36,
+        "column": {
+          "start": 7,
+          "end": 65
+        },
+        "content": "x.prepareStatement(\\"select \\" + request.getParameter(\\"id\\"))"
+      },
+      "parent_line_number": 36,
+      "snippet": "x.prepareStatement(\\"select \\" + request.getParameter(\\"id\\"))",
+      "fingerprint": "79d5d495c5c408c582b32582f1ae9171_3",
+      "old_fingerprint": "db6f664c606e5cc7e0b287583ab73e93_3",
+      "code_extract": "      x.prepareStatement(\\"select \\" + request.getParameter(\\"id\\"));"
+    },
+    {
+      "cwe_ids": [
+        "89"
+      ],
+      "id": "java_lang_sqli",
+      "title": "Unsanitized user input in SQL query detected.",
+      "description": "## Description\\n\\nIncluding unsanitized data, such as user input or request data, in raw SQL\\nqueries makes your application vulnerable to SQL injection attacks.\\n\\n## Remediations\\n\\n❌ Avoid raw queries, especially those that contain unsanitized user input:\\n\\n\`\`\`java\\n  Statement stmt = conn.createStatement();\\n  ResultSet rs = stmt.executeQuery(\\"select name from users where id='\\"+ uri.getQueryParameter(\\"user_id\\") \\"'\\")) {\\n\`\`\`\\n\\n✅ Instead of using dynamically crafted strings for your SQL queries, use prepared statements instead\\n\\n\`\`\`java\\nmyStmt = myCon.prepareStatement(\\"select * from students where age > ? and name = ?\\");\\nmyStmt.setInt(1, uri.getQueryParameter(\\"age\\"));\\nmyStmt.setString(2, uri.getQueryParameter(\\"name\\"));\\n\`\`\`\\n\\n## Resources\\n- [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)\\n- [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/java_lang_sqli",
+      "line_number": 40,
+      "full_filename": "/tmp/bearer-scan/bad.java",
+      "filename": ".",
+      "source": {
+        "start": 40,
+        "end": 40,
+        "column": {
+          "start": 7,
+          "end": 61
+        }
+      },
+      "sink": {
+        "start": 40,
+        "end": 40,
+        "column": {
+          "start": 7,
+          "end": 61
+        },
+        "content": "x.executeQuery(\\"select \\" + request.getParameter(\\"id\\"))"
+      },
+      "parent_line_number": 40,
+      "snippet": "x.executeQuery(\\"select \\" + request.getParameter(\\"id\\"))",
+      "fingerprint": "79d5d495c5c408c582b32582f1ae9171_4",
+      "old_fingerprint": "db6f664c606e5cc7e0b287583ab73e93_4",
+      "code_extract": "      x.executeQuery(\\"select \\" + request.getParameter(\\"id\\"));"
+    },
+    {
+      "cwe_ids": [
+        "89"
+      ],
+      "id": "java_lang_sqli",
+      "title": "Unsanitized user input in SQL query detected.",
+      "description": "## Description\\n\\nIncluding unsanitized data, such as user input or request data, in raw SQL\\nqueries makes your application vulnerable to SQL injection attacks.\\n\\n## Remediations\\n\\n❌ Avoid raw queries, especially those that contain unsanitized user input:\\n\\n\`\`\`java\\n  Statement stmt = conn.createStatement();\\n  ResultSet rs = stmt.executeQuery(\\"select name from users where id='\\"+ uri.getQueryParameter(\\"user_id\\") \\"'\\")) {\\n\`\`\`\\n\\n✅ Instead of using dynamically crafted strings for your SQL queries, use prepared statements instead\\n\\n\`\`\`java\\nmyStmt = myCon.prepareStatement(\\"select * from students where age > ? and name = ?\\");\\nmyStmt.setInt(1, uri.getQueryParameter(\\"age\\"));\\nmyStmt.setString(2, uri.getQueryParameter(\\"name\\"));\\n\`\`\`\\n\\n## Resources\\n- [OWASP SQL injection explained](https://owasp.org/www-community/attacks/SQL_Injection)\\n- [OWASP SQL injection prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/java_lang_sqli",
+      "line_number": 44,
+      "full_filename": "/tmp/bearer-scan/bad.java",
+      "filename": ".",
+      "source": {
+        "start": 44,
+        "end": 44,
+        "column": {
+          "start": 7,
+          "end": 60
+        }
+      },
+      "sink": {
+        "start": 44,
+        "end": 44,
+        "column": {
+          "start": 7,
+          "end": 60
+        },
+        "content": "x.createQuery(\\"select \\" + request.getParameter(\\"id\\"))"
+      },
+      "parent_line_number": 44,
+      "snippet": "x.createQuery(\\"select \\" + request.getParameter(\\"id\\"))",
+      "fingerprint": "79d5d495c5c408c582b32582f1ae9171_5",
+      "old_fingerprint": "db6f664c606e5cc7e0b287583ab73e93_5",
+      "code_extract": "      x.createQuery(\\"select \\" + request.getParameter(\\"id\\"));"
     }
   ]
 }"

--- a/tests/java/lang/xpath_injection/__snapshots__/test.js.snap
+++ b/tests/java/lang/xpath_injection/__snapshots__/test.js.snap
@@ -11,6 +11,40 @@ exports[`java_lang_xpath_injection xpath_injection 1`] = `
       "title": "XPATH injection threat detected",
       "description": "## Description\\n  Unsanitized input going into XPath evaluate detected.\\n  This could lead to xpath injection if variables passed into the evaluate or compile commands are not properly sanitized.\\n  Xpath injection could lead to unauthorized access to sensitive information in XML documents.\\n  Instead, thoroughly sanitize user input or use parameterized xpath queries if you can.\\n\\n## Remediations\\n\\n✅ Sanitize XPATH queries\\n\\n\`\`\`java\\n  public class Cls extends HttpServlet\\n  {\\n\\n      public void handleRequest(HttpServletRequest request, HttpServletResponse response)\\n      {\\n          String userID = request.getParameter(\\"userID\\");\\n          String sanitizedUserID = sanitize(userID);\\n\\n          javax.xml.xpath.XPathFactory xpf = javax.xml.xpath.XPathFactory.newInstance();\\n          javax.xml.xpath.XPath xp = xpf.newXPath();\\n\\n          String expression = \\"/Users/User[@userID='\\" + sanitizedUserID + \\"']\\";\\n          String result = xp.evaluate(expression, xmlDocument);\\n      }\\n  }\\n\`\`\`\\n\\n## References\\n- [XPATH Injection](https://owasp.org/www-community/attacks/XPATH_Injection)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/java_lang_xpath_injection",
+      "line_number": 12,
+      "full_filename": "/tmp/bearer-scan/xpath_injection.java",
+      "filename": ".",
+      "source": {
+        "start": 12,
+        "end": 12,
+        "column": {
+          "start": 25,
+          "end": 61
+        }
+      },
+      "sink": {
+        "start": 12,
+        "end": 12,
+        "column": {
+          "start": 25,
+          "end": 61
+        },
+        "content": "xp.evaluate(expression, xmlDocument)"
+      },
+      "parent_line_number": 12,
+      "snippet": "xp.evaluate(expression, xmlDocument)",
+      "fingerprint": "d8456dfb1c7f1ed1b1c088e426430687_0",
+      "old_fingerprint": "a1c9a49efc8e4e79a8407bbb5e677663_0",
+      "code_extract": "        String result = xp.evaluate(expression, xmlDocument);"
+    },
+    {
+      "cwe_ids": [
+        "643"
+      ],
+      "id": "java_lang_xpath_injection",
+      "title": "XPATH injection threat detected",
+      "description": "## Description\\n  Unsanitized input going into XPath evaluate detected.\\n  This could lead to xpath injection if variables passed into the evaluate or compile commands are not properly sanitized.\\n  Xpath injection could lead to unauthorized access to sensitive information in XML documents.\\n  Instead, thoroughly sanitize user input or use parameterized xpath queries if you can.\\n\\n## Remediations\\n\\n✅ Sanitize XPATH queries\\n\\n\`\`\`java\\n  public class Cls extends HttpServlet\\n  {\\n\\n      public void handleRequest(HttpServletRequest request, HttpServletResponse response)\\n      {\\n          String userID = request.getParameter(\\"userID\\");\\n          String sanitizedUserID = sanitize(userID);\\n\\n          javax.xml.xpath.XPathFactory xpf = javax.xml.xpath.XPathFactory.newInstance();\\n          javax.xml.xpath.XPath xp = xpf.newXPath();\\n\\n          String expression = \\"/Users/User[@userID='\\" + sanitizedUserID + \\"']\\";\\n          String result = xp.evaluate(expression, xmlDocument);\\n      }\\n  }\\n\`\`\`\\n\\n## References\\n- [XPATH Injection](https://owasp.org/www-community/attacks/XPATH_Injection)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/java_lang_xpath_injection",
       "line_number": 14,
       "full_filename": "/tmp/bearer-scan/xpath_injection.java",
       "filename": ".",
@@ -33,8 +67,8 @@ exports[`java_lang_xpath_injection xpath_injection 1`] = `
       },
       "parent_line_number": 14,
       "snippet": "xpf.newXPath().compile(expression)",
-      "fingerprint": "d8456dfb1c7f1ed1b1c088e426430687_0",
-      "old_fingerprint": "a1c9a49efc8e4e79a8407bbb5e677663_0",
+      "fingerprint": "d8456dfb1c7f1ed1b1c088e426430687_1",
+      "old_fingerprint": "a1c9a49efc8e4e79a8407bbb5e677663_1",
       "code_extract": "        var compiled = xpf.newXPath().compile(expression);"
     }
   ]

--- a/tests/javascript/lang/file_generation/__snapshots__/test.js.snap
+++ b/tests/javascript/lang/file_generation/__snapshots__/test.js.snap
@@ -11,6 +11,48 @@ exports[`javascript_lang_file_generation file_generation 1`] = `
       "title": "Sensitive data detected as part of a dynamic file generation.",
       "description": "## Description\\n\\nIt is not uncommon to generate logs, backups, or data exports to static file formats. This rule checks if code exists to write sensitive data to static files.\\n\\n## Remediations\\n\\nAvoid writing sensitive data to logs, backups, or exports whenever possible. Instead obfuscate and/or filter the data to exclude sensitive information.\\n\\n<!--\\n## Resources\\nComing soon.\\n-->\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/javascript_lang_file_generation",
+      "line_number": 7,
+      "full_filename": "/tmp/bearer-scan/file_generation.js",
+      "filename": ".",
+      "data_type": {
+        "category_uuid": "14124881-6b92-4fc5-8005-ea7c1c09592e",
+        "name": "Firstname"
+      },
+      "category_groups": [
+        "PII",
+        "Personal Data"
+      ],
+      "source": {
+        "start": 7,
+        "end": 7,
+        "column": {
+          "start": 35,
+          "end": 49
+        }
+      },
+      "sink": {
+        "start": 15,
+        "end": 18,
+        "column": {
+          "start": 1,
+          "end": 3
+        },
+        "content": "fs.writeFile(\\"data.csv\\", JSON.stringify(users), \\"utf-8\\", (err) => {\\n  if (err) console.log(err)\\n  else console.log(\\"Data saved\\")\\n})"
+      },
+      "parent_line_number": 15,
+      "snippet": "fs.writeFile(\\"data.csv\\", JSON.stringify(users), \\"utf-8\\", (err) => {\\n  if (err) console.log(err)\\n  else console.log(\\"Data saved\\")\\n})",
+      "fingerprint": "7162a96ee591e4689c1fa24bfcc02fd5_0",
+      "old_fingerprint": "e07392ef7687a29685f9b9f7fd673469_0",
+      "code_extract": "fs.writeFile(\\"data.csv\\", JSON.stringify(users), \\"utf-8\\", (err) => {\\n  if (err) console.log(err)\\n  else console.log(\\"Data saved\\")\\n})"
+    },
+    {
+      "cwe_ids": [
+        "313"
+      ],
+      "id": "javascript_lang_file_generation",
+      "title": "Sensitive data detected as part of a dynamic file generation.",
+      "description": "## Description\\n\\nIt is not uncommon to generate logs, backups, or data exports to static file formats. This rule checks if code exists to write sensitive data to static files.\\n\\n## Remediations\\n\\nAvoid writing sensitive data to logs, backups, or exports whenever possible. Instead obfuscate and/or filter the data to exclude sensitive information.\\n\\n<!--\\n## Resources\\nComing soon.\\n-->\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/javascript_lang_file_generation",
       "line_number": 9,
       "full_filename": "/tmp/bearer-scan/file_generation.js",
       "filename": ".",
@@ -41,8 +83,8 @@ exports[`javascript_lang_file_generation file_generation 1`] = `
       },
       "parent_line_number": 15,
       "snippet": "fs.writeFile(\\"data.csv\\", JSON.stringify(users), \\"utf-8\\", (err) => {\\n  if (err) console.log(err)\\n  else console.log(\\"Data saved\\")\\n})",
-      "fingerprint": "7162a96ee591e4689c1fa24bfcc02fd5_0",
-      "old_fingerprint": "e07392ef7687a29685f9b9f7fd673469_0",
+      "fingerprint": "7162a96ee591e4689c1fa24bfcc02fd5_2",
+      "old_fingerprint": "e07392ef7687a29685f9b9f7fd673469_2",
       "code_extract": "fs.writeFile(\\"data.csv\\", JSON.stringify(users), \\"utf-8\\", (err) => {\\n  if (err) console.log(err)\\n  else console.log(\\"Data saved\\")\\n})"
     },
     {
@@ -83,8 +125,8 @@ exports[`javascript_lang_file_generation file_generation 1`] = `
       },
       "parent_line_number": 15,
       "snippet": "fs.writeFile(\\"data.csv\\", JSON.stringify(users), \\"utf-8\\", (err) => {\\n  if (err) console.log(err)\\n  else console.log(\\"Data saved\\")\\n})",
-      "fingerprint": "7162a96ee591e4689c1fa24bfcc02fd5_1",
-      "old_fingerprint": "e07392ef7687a29685f9b9f7fd673469_1",
+      "fingerprint": "7162a96ee591e4689c1fa24bfcc02fd5_3",
+      "old_fingerprint": "e07392ef7687a29685f9b9f7fd673469_3",
       "code_extract": "fs.writeFile(\\"data.csv\\", JSON.stringify(users), \\"utf-8\\", (err) => {\\n  if (err) console.log(err)\\n  else console.log(\\"Data saved\\")\\n})"
     }
   ]

--- a/tests/javascript/lang/logger/__snapshots__/test.js.snap
+++ b/tests/javascript/lang/logger/__snapshots__/test.js.snap
@@ -62,6 +62,49 @@ exports[`javascript_lang_logger child_level 1`] = `
       "title": "Sensitive data in a logger message detected.",
       "description": "## Description\\n\\nLeaking sensitive data to loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to loggers.\\n\\n## Remediations\\n\\n❌ Avoid using sensitive data in logger messages:\\n\\n\`\`\`javascript\\nlogger.info(\`User is: \${user.email}\`)\\n\`\`\`\\n\\n✅ If you need to identify a user, use their unique identifier instead of their personal identifiable information:\\n\\n\`\`\`javascript\\nlogger.info(\`User is: \${user.uuid}\`)\\n\`\`\`\\n## Resources\\n- [OWASP logging cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/javascript_lang_logger",
+      "line_number": 3,
+      "full_filename": "/tmp/bearer-scan/child_level.js",
+      "filename": ".",
+      "data_type": {
+        "category_uuid": "cef587dd-76db-430b-9e18-7b031e1a193b",
+        "name": "Email Address"
+      },
+      "category_groups": [
+        "PII",
+        "Personal Data"
+      ],
+      "source": {
+        "start": 3,
+        "end": 3,
+        "column": {
+          "start": 3,
+          "end": 27
+        }
+      },
+      "sink": {
+        "start": 7,
+        "end": 7,
+        "column": {
+          "start": 1,
+          "end": 18
+        },
+        "content": "logger.child(ctx)"
+      },
+      "parent_line_number": 7,
+      "snippet": "logger.child(ctx)",
+      "fingerprint": "327449cd47ed82672cc47bf9cfccdb4a_0",
+      "old_fingerprint": "02e247f69b1c812c168a85bc9af2be8d_0",
+      "code_extract": "logger.child(ctx).info(user.name);"
+    },
+    {
+      "cwe_ids": [
+        "1295",
+        "532"
+      ],
+      "id": "javascript_lang_logger",
+      "title": "Sensitive data in a logger message detected.",
+      "description": "## Description\\n\\nLeaking sensitive data to loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to loggers.\\n\\n## Remediations\\n\\n❌ Avoid using sensitive data in logger messages:\\n\\n\`\`\`javascript\\nlogger.info(\`User is: \${user.email}\`)\\n\`\`\`\\n\\n✅ If you need to identify a user, use their unique identifier instead of their personal identifiable information:\\n\\n\`\`\`javascript\\nlogger.info(\`User is: \${user.uuid}\`)\\n\`\`\`\\n## Resources\\n- [OWASP logging cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/javascript_lang_logger",
       "line_number": 7,
       "full_filename": "/tmp/bearer-scan/child_level.js",
       "filename": ".",
@@ -92,8 +135,8 @@ exports[`javascript_lang_logger child_level 1`] = `
       },
       "parent_line_number": 7,
       "snippet": "logger.child(ctx).info(user.name)",
-      "fingerprint": "327449cd47ed82672cc47bf9cfccdb4a_0",
-      "old_fingerprint": "02e247f69b1c812c168a85bc9af2be8d_0",
+      "fingerprint": "327449cd47ed82672cc47bf9cfccdb4a_1",
+      "old_fingerprint": "02e247f69b1c812c168a85bc9af2be8d_1",
       "code_extract": "logger.child(ctx).info(user.name);"
     }
   ]

--- a/tests/javascript/lang/manual_html_sanitization/__snapshots__/test.js.snap
+++ b/tests/javascript/lang/manual_html_sanitization/__snapshots__/test.js.snap
@@ -29,12 +29,12 @@ exports[`javascript_lang_manual_html_sanitization unsafe 1`] = `
         "end": 1,
         "column": {
           "start": 28,
-          "end": 86
+          "end": 62
         },
-        "content": "user.Input.replaceAll('<', '&lt;').replaceAll('>', '&gt;')"
+        "content": "user.Input.replaceAll('<', '&lt;')"
       },
       "parent_line_number": 1,
-      "snippet": "user.Input.replaceAll('<', '&lt;').replaceAll('>', '&gt;')",
+      "snippet": "user.Input.replaceAll('<', '&lt;')",
       "fingerprint": "883581e9effcc89f50531cd2677ebf31_0",
       "old_fingerprint": "f64354c034f32ea4927e1f751b63cb3b_0",
       "code_extract": "const sanitizedUserInput = user.Input.replaceAll('<', '&lt;').replaceAll('>', '&gt;');"

--- a/tests/javascript/third_parties/new_relic/__snapshots__/test.js.snap
+++ b/tests/javascript/third_parties/new_relic/__snapshots__/test.js.snap
@@ -11,6 +11,48 @@ exports[`javascript_third_parties_new_relic datatype_in_interaction_set_attribut
       "title": "Sensitive data sent to New Relic detected.",
       "description": "## Description\\nLeaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to New Relic.\\n\\n## Remediations\\n\\nWhen logging errors or events, ensure all sensitive data is removed.\\n\\n## Resources\\n- [New Relic Docs](https://docs.newrelic.com/)\\n- [Log obfuscation](https://docs.newrelic.com/docs/logs/ui-data/obfuscation-ui/)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic",
+      "line_number": 6,
+      "full_filename": "/tmp/bearer-scan/datatype_in_interaction_set_attribute.js",
+      "filename": ".",
+      "data_type": {
+        "category_uuid": "14124881-6b92-4fc5-8005-ea7c1c09592e",
+        "name": "Firstname"
+      },
+      "category_groups": [
+        "PII",
+        "Personal Data"
+      ],
+      "source": {
+        "start": 6,
+        "end": 6,
+        "column": {
+          "start": 31,
+          "end": 46
+        }
+      },
+      "sink": {
+        "start": 5,
+        "end": 6,
+        "column": {
+          "start": 3,
+          "end": 47
+        },
+        "content": "newrelic.interaction()\\n    .setAttribute(\\"username\\", user.first_name)"
+      },
+      "parent_line_number": 5,
+      "snippet": "newrelic.interaction()\\n    .setAttribute(\\"username\\", user.first_name)",
+      "fingerprint": "63161101404765527f0dada7fd00b64e_0",
+      "old_fingerprint": "d4a33ef10c96118848e50cbe6babe62c_0",
+      "code_extract": "  newrelic.interaction()\\n    .setAttribute(\\"username\\", user.first_name)"
+    },
+    {
+      "cwe_ids": [
+        "201"
+      ],
+      "id": "javascript_third_parties_new_relic",
+      "title": "Sensitive data sent to New Relic detected.",
+      "description": "## Description\\nLeaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to New Relic.\\n\\n## Remediations\\n\\nWhen logging errors or events, ensure all sensitive data is removed.\\n\\n## Resources\\n- [New Relic Docs](https://docs.newrelic.com/)\\n- [Log obfuscation](https://docs.newrelic.com/docs/logs/ui-data/obfuscation-ui/)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic",
       "line_number": 7,
       "full_filename": "/tmp/bearer-scan/datatype_in_interaction_set_attribute.js",
       "filename": ".",
@@ -41,8 +83,8 @@ exports[`javascript_third_parties_new_relic datatype_in_interaction_set_attribut
       },
       "parent_line_number": 5,
       "snippet": "newrelic.interaction()\\n    .setAttribute(\\"username\\", user.first_name)\\n    .setAttribute(\\"postal-code\\", user.post_code)",
-      "fingerprint": "63161101404765527f0dada7fd00b64e_0",
-      "old_fingerprint": "d4a33ef10c96118848e50cbe6babe62c_0",
+      "fingerprint": "63161101404765527f0dada7fd00b64e_1",
+      "old_fingerprint": "d4a33ef10c96118848e50cbe6babe62c_1",
       "code_extract": "  newrelic.interaction()\\n    .setAttribute(\\"username\\", user.first_name)\\n    .setAttribute(\\"postal-code\\", user.post_code);"
     },
     {
@@ -83,8 +125,8 @@ exports[`javascript_third_parties_new_relic datatype_in_interaction_set_attribut
       },
       "parent_line_number": 13,
       "snippet": "interaction.setAttribute(\\"email\\", user.email_address)",
-      "fingerprint": "63161101404765527f0dada7fd00b64e_1",
-      "old_fingerprint": "d4a33ef10c96118848e50cbe6babe62c_1",
+      "fingerprint": "63161101404765527f0dada7fd00b64e_2",
+      "old_fingerprint": "d4a33ef10c96118848e50cbe6babe62c_2",
       "code_extract": "interaction.setAttribute(\\"email\\", user.email_address)"
     }
   ]

--- a/tests/ruby/lang/http_url_using_user_input/__snapshots__/test.js.snap
+++ b/tests/ruby/lang/http_url_using_user_input/__snapshots__/test.js.snap
@@ -782,6 +782,40 @@ exports[`ruby_lang_http_url_using_user_input unsafe_net_http 1`] = `
       "title": "HTTP communication with user-controlled destination detected.",
       "description": "## Description\\n\\nApplications should not connect to locations formed from user input.\\nThis rule checks for URLs containing user-supplied data.\\n\\n## Remediations\\n\\n❌ Avoid using user input in HTTP URLs:\\n\\n\`\`\`ruby\\nFaraday.get(\\"https://#{params[:host]}')\\n\`\`\`\\n\\n✅ Use user input indirectly to form a URL:\\n\\n\`\`\`ruby\\nhost =\\n  case params[:host]\\n  when \\"option1\\"\\n    \\"api1.com\\"\\n  when \\"option2\\"\\n    \\"api2.com\\"\\n  end\\n\\nFaraday.get(\\"https://#{host}')\\n\`\`\`\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input",
+      "line_number": 6,
+      "full_filename": "/tmp/bearer-scan/unsafe_net_http.rb",
+      "filename": ".",
+      "source": {
+        "start": 6,
+        "end": 6,
+        "column": {
+          "start": 3,
+          "end": 32
+        }
+      },
+      "sink": {
+        "start": 6,
+        "end": 6,
+        "column": {
+          "start": 3,
+          "end": 32
+        },
+        "content": "instance1.head(params[:path])"
+      },
+      "parent_line_number": 6,
+      "snippet": "instance1.head(params[:path])",
+      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_2",
+      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_2",
+      "code_extract": "  instance1.head(params[:path])"
+    },
+    {
+      "cwe_ids": [
+        "918"
+      ],
+      "id": "ruby_lang_http_url_using_user_input",
+      "title": "HTTP communication with user-controlled destination detected.",
+      "description": "## Description\\n\\nApplications should not connect to locations formed from user input.\\nThis rule checks for URLs containing user-supplied data.\\n\\n## Remediations\\n\\n❌ Avoid using user input in HTTP URLs:\\n\\n\`\`\`ruby\\nFaraday.get(\\"https://#{params[:host]}')\\n\`\`\`\\n\\n✅ Use user input indirectly to form a URL:\\n\\n\`\`\`ruby\\nhost =\\n  case params[:host]\\n  when \\"option1\\"\\n    \\"api1.com\\"\\n  when \\"option2\\"\\n    \\"api2.com\\"\\n  end\\n\\nFaraday.get(\\"https://#{host}')\\n\`\`\`\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/ruby_lang_http_url_using_user_input",
       "line_number": 9,
       "full_filename": "/tmp/bearer-scan/unsafe_net_http.rb",
       "filename": ".",
@@ -804,8 +838,8 @@ exports[`ruby_lang_http_url_using_user_input unsafe_net_http 1`] = `
       },
       "parent_line_number": 9,
       "snippet": "Net::HTTP::Get.new(params[:oops], { \\"X-Test\\": 42 })",
-      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_2",
-      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_2",
+      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_3",
+      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_3",
       "code_extract": "Net::HTTP::Get.new(params[:oops], { \\"X-Test\\": 42 })"
     },
     {
@@ -838,8 +872,8 @@ exports[`ruby_lang_http_url_using_user_input unsafe_net_http 1`] = `
       },
       "parent_line_number": 11,
       "snippet": "Net::HTTP.start(params[:oops])",
-      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_3",
-      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_3",
+      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_4",
+      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_4",
       "code_extract": "instance2 = Net::HTTP.start(params[:oops])"
     },
     {
@@ -872,8 +906,8 @@ exports[`ruby_lang_http_url_using_user_input unsafe_net_http 1`] = `
       },
       "parent_line_number": 12,
       "snippet": "instance2.ipaddr = request.env[:oops]",
-      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_4",
-      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_4",
+      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_5",
+      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_5",
       "code_extract": "instance2.ipaddr = request.env[:oops]"
     },
     {
@@ -906,8 +940,8 @@ exports[`ruby_lang_http_url_using_user_input unsafe_net_http 1`] = `
       },
       "parent_line_number": 13,
       "snippet": "instance2.send_request(\\"GET\\", params[:oops], nil)",
-      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_5",
-      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_5",
+      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_6",
+      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_6",
       "code_extract": "instance2.send_request(\\"GET\\", params[:oops], nil)"
     },
     {
@@ -940,8 +974,8 @@ exports[`ruby_lang_http_url_using_user_input unsafe_net_http 1`] = `
       },
       "parent_line_number": 15,
       "snippet": "Net::HTTP.new(params[:oops])",
-      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_6",
-      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_6",
+      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_7",
+      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_7",
       "code_extract": "instance3 = Net::HTTP.new(params[:oops])"
     },
     {
@@ -974,8 +1008,8 @@ exports[`ruby_lang_http_url_using_user_input unsafe_net_http 1`] = `
       },
       "parent_line_number": 16,
       "snippet": "instance3.patch(params[:path])",
-      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_7",
-      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_7",
+      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_8",
+      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_8",
       "code_extract": "instance3.patch(params[:path])"
     },
     {
@@ -1008,8 +1042,8 @@ exports[`ruby_lang_http_url_using_user_input unsafe_net_http 1`] = `
       },
       "parent_line_number": 18,
       "snippet": "instance4.post(request.env[:oops])",
-      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_8",
-      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_8",
+      "fingerprint": "f8b7e1c48c1bb6e71f6a8996b228371b_9",
+      "old_fingerprint": "8a18caa1fbaa41082d9423ffb7a8e20a_9",
       "code_extract": "  instance4.post(request.env[:oops])"
     }
   ]

--- a/tests/ruby/lang/manual_html_sanitization/__snapshots__/test.js.snap
+++ b/tests/ruby/lang/manual_html_sanitization/__snapshots__/test.js.snap
@@ -26,18 +26,18 @@ exports[`ruby_lang_manual_html_sanitization unsafe 1`] = `
       },
       "sink": {
         "start": 1,
-        "end": 3,
+        "end": 2,
         "column": {
           "start": 24,
           "end": 21
         },
-        "content": "user.Input\\n  .gsub('<', '&lt;')\\n  .gsub('>', '&gt;')"
+        "content": "user.Input\\n  .gsub('<', '&lt;')"
       },
       "parent_line_number": 1,
-      "snippet": "user.Input\\n  .gsub('<', '&lt;')\\n  .gsub('>', '&gt;')",
+      "snippet": "user.Input\\n  .gsub('<', '&lt;')",
       "fingerprint": "2a5444c188b207201b5ce8c74ed321fe_0",
       "old_fingerprint": "dd0ed0b0b63f9147a628422412658b4c_0",
-      "code_extract": "sanitized_user_input = user.Input\\n  .gsub('<', '&lt;')\\n  .gsub('>', '&gt;')"
+      "code_extract": "sanitized_user_input = user.Input\\n  .gsub('<', '&lt;')"
     }
   ]
 }"

--- a/tests/ruby/lang/raw_html_using_user_input/__snapshots__/test.js.snap
+++ b/tests/ruby/lang/raw_html_using_user_input/__snapshots__/test.js.snap
@@ -128,13 +128,13 @@ exports[`ruby_lang_raw_html_using_user_input bad 1`] = `
         "start": 5,
         "end": 5,
         "column": {
-          "start": 1,
-          "end": 33
+          "start": 5,
+          "end": 32
         },
-        "content": "raw(\\"<h1>#{params[:oops]}</h1>\\")"
+        "content": "\\"<h1>#{params[:oops]}</h1>\\""
       },
       "parent_line_number": 5,
-      "snippet": "raw(\\"<h1>#{params[:oops]}</h1>\\")",
+      "snippet": "\\"<h1>#{params[:oops]}</h1>\\"",
       "fingerprint": "bbce316340479255472a6bc49330c542_3",
       "old_fingerprint": "eef01466c0f4aefe92a29f710d1513d9_3",
       "code_extract": "raw(\\"<h1>#{params[:oops]}</h1>\\")"
@@ -169,8 +169,8 @@ exports[`ruby_lang_raw_html_using_user_input bad 1`] = `
       },
       "parent_line_number": 7,
       "snippet": "\\"Hello: #{params[:oops]}\\".html_safe",
-      "fingerprint": "bbce316340479255472a6bc49330c542_4",
-      "old_fingerprint": "eef01466c0f4aefe92a29f710d1513d9_4",
+      "fingerprint": "bbce316340479255472a6bc49330c542_5",
+      "old_fingerprint": "eef01466c0f4aefe92a29f710d1513d9_5",
       "code_extract": "\\"Hello: #{params[:oops]}\\".html_safe"
     },
     {
@@ -203,8 +203,8 @@ exports[`ruby_lang_raw_html_using_user_input bad 1`] = `
       },
       "parent_line_number": 9,
       "snippet": "ERB.new(\\"Test: \\" + params[:oops])",
-      "fingerprint": "bbce316340479255472a6bc49330c542_5",
-      "old_fingerprint": "eef01466c0f4aefe92a29f710d1513d9_5",
+      "fingerprint": "bbce316340479255472a6bc49330c542_6",
+      "old_fingerprint": "eef01466c0f4aefe92a29f710d1513d9_6",
       "code_extract": "ERB.new(\\"Test: \\" + params[:oops])"
     }
   ]

--- a/tests/ruby/rails/sql_injection/__snapshots__/test.js.snap
+++ b/tests/ruby/rails/sql_injection/__snapshots__/test.js.snap
@@ -203,8 +203,8 @@ exports[`ruby_rails_sql_injection injected_params 1`] = `
       },
       "parent_line_number": 11,
       "snippet": "ActiveRecord::Base.connection.exec_query(\\"SELECT #{params[:oops]}\\")",
-      "fingerprint": "4375e8a33c7009e3ee375e18f3a797b1_5",
-      "old_fingerprint": "a81302659c0d03a625eebd21fae512b5_5",
+      "fingerprint": "4375e8a33c7009e3ee375e18f3a797b1_6",
+      "old_fingerprint": "a81302659c0d03a625eebd21fae512b5_6",
       "code_extract": "ActiveRecord::Base.connection.exec_query(\\"SELECT #{params[:oops]}\\")"
     },
     {
@@ -237,8 +237,8 @@ exports[`ruby_rails_sql_injection injected_params 1`] = `
       },
       "parent_line_number": 13,
       "snippet": "connection.select_all(\\"SELECT #{params[:oops]}\\")",
-      "fingerprint": "4375e8a33c7009e3ee375e18f3a797b1_6",
-      "old_fingerprint": "a81302659c0d03a625eebd21fae512b5_6",
+      "fingerprint": "4375e8a33c7009e3ee375e18f3a797b1_7",
+      "old_fingerprint": "a81302659c0d03a625eebd21fae512b5_7",
       "code_extract": "connection.select_all(\\"SELECT #{params[:oops]}\\")"
     }
   ]

--- a/tests/ruby/third_parties/open_telemetry/__snapshots__/test.js.snap
+++ b/tests/ruby/third_parties/open_telemetry/__snapshots__/test.js.snap
@@ -367,6 +367,48 @@ exports[`ruby_third_parties_open_telemetry datatypes_in_span_init_block 1`] = `
       "title": "Sensitive data sent to Open Telemetry detected.",
       "description": "## Description\\nLeaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Open Telemetry.\\n\\n## Remediations\\n\\nWhen logging errors or events, ensure all sensitive data is removed.\\n\\n## Resources\\n- [Open Telemetry Docs](https://opentelemetry.io/docs/)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry",
+      "line_number": 7,
+      "full_filename": "/tmp/bearer-scan/datatypes_in_span_init_block.rb",
+      "filename": ".",
+      "data_type": {
+        "category_uuid": "cef587dd-76db-430b-9e18-7b031e1a193b",
+        "name": "Email Address"
+      },
+      "category_groups": [
+        "PII",
+        "Personal Data"
+      ],
+      "source": {
+        "start": 7,
+        "end": 7,
+        "column": {
+          "start": 23,
+          "end": 33
+        }
+      },
+      "sink": {
+        "start": 7,
+        "end": 7,
+        "column": {
+          "start": 3,
+          "end": 34
+        },
+        "content": "span.add_attributes(user.email)"
+      },
+      "parent_line_number": 7,
+      "snippet": "span.add_attributes(user.email)",
+      "fingerprint": "949ba3eb3d0c9c539480c41846520b5b_2",
+      "old_fingerprint": "e3c915377ea892d2c15b106449f05e8c_2",
+      "code_extract": "  span.add_attributes(user.email)"
+    },
+    {
+      "cwe_ids": [
+        "201"
+      ],
+      "id": "ruby_third_parties_open_telemetry",
+      "title": "Sensitive data sent to Open Telemetry detected.",
+      "description": "## Description\\nLeaking sensitive data to third-party loggers is a common cause of data leaks and can lead to data breaches. This rule looks for instances of sensitive data sent to Open Telemetry.\\n\\n## Remediations\\n\\nWhen logging errors or events, ensure all sensitive data is removed.\\n\\n## Resources\\n- [Open Telemetry Docs](https://opentelemetry.io/docs/)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry",
       "line_number": 11,
       "full_filename": "/tmp/bearer-scan/datatypes_in_span_init_block.rb",
       "filename": ".",
@@ -397,8 +439,8 @@ exports[`ruby_third_parties_open_telemetry datatypes_in_span_init_block 1`] = `
       },
       "parent_line_number": 11,
       "snippet": "span.add_event(\\"leaking data for #{user.email}\\")",
-      "fingerprint": "949ba3eb3d0c9c539480c41846520b5b_2",
-      "old_fingerprint": "e3c915377ea892d2c15b106449f05e8c_2",
+      "fingerprint": "949ba3eb3d0c9c539480c41846520b5b_3",
+      "old_fingerprint": "e3c915377ea892d2c15b106449f05e8c_3",
       "code_extract": "  span.add_event(\\"leaking data for #{user.email}\\")"
     }
   ]


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Updates snapshots for the latest CLI. The changes are as follows.

New detections (valid findings the old CLI couldn't detect):
- `java_lang_os_command_injection`
- `java_lang_sqli`
- `java_lang_xpath_injection`
- `javascript_lang_file_generation`
- `javascript_lang_logger`
- `javascript_third_parties_new_relic`
- `ruby_lang_http_url_using_user_input`
- `ruby_third_parties_open_telemetry`

Small changes to the exact code content matched (no difference in fingerprint or meaning of findings):
- `javascript_lang_manual_html_sanitization`
- `ruby_lang_manual_html_sanitization`
- `ruby_lang_raw_html_using_user_input`

Changes to fingerprints because of differences in the number/order of duplicate detections:
- `ruby_lang_raw_html_using_user_input`
- `ruby_rails_sql_injection`

The duplicate detections issue relates to detecting nested detections, commonly in chained method calls. Previously, we would have a single detection for this code:

```ruby
User
  .where(params[:oops])
  .order(params[:oops2])
```

Whereas now we find both detections, but they are then de-duplicated as the matches overlap in lines. This change in functionality is also responsible for some of the new findings we want to keep, so we don't want to change it. We've decided to accept the change in fingerprint for these few cases.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
