### PR TITLE
fix: improve jwt not revoked rules and tests

### DIFF
--- a/rules/javascript/express/jwt_not_revoked.yml
+++ b/rules/javascript/express/jwt_not_revoked.yml
@@ -6,11 +6,11 @@ patterns:
         regex: (?i)\A(expressjwt)\z
       - variable: HASH_CONTENT
         detection: javascript_express_jwt_not_revoked_secret
-        scope: cursor
+        scope: result
       - not:
           variable: HASH_CONTENT
           detection: javascript_express_jwt_not_revoked_is_revoked
-          scope: cursor
+          scope: result
 languages:
   - javascript
 auxiliary:

--- a/tests/javascript/express/jwt_not_revoked/__snapshots__/test.js.snap
+++ b/tests/javascript/express/jwt_not_revoked/__snapshots__/test.js.snap
@@ -109,4 +109,79 @@ exports[`javascript_express_jwt_not_revoked express_jwt_not_revoked 1`] = `
 }"
 `;
 
+exports[`javascript_express_jwt_not_revoked insecurity_express_jwt_revoked 1`] = `
+"{
+  "low": [
+    {
+      "cwe_ids": [
+        "525"
+      ],
+      "id": "javascript_express_jwt_not_revoked",
+      "title": "Unrevoked JWT detected.",
+      "description": "## Description\\nThe best practice caching policy is to revoke JWTs especially when these contain senstitive information.\\n\\n## Remediations\\n✅ Ensure JWTs are short-lived by revoking them\\n\\n\`\`\`javascript\\nexpressjwt({\\n  ...\\n  isRevoked: this.customRevokeCall(),\\n  ...\\n})\\n\`\`\`\\n\\n## Resources\\n- [ExpressJWT documentation on revoking tokens](https://github.com/auth0/express-jwt#revoked-tokens)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/javascript_express_jwt_not_revoked",
+      "line_number": 1,
+      "full_filename": "/tmp/bearer-scan/insecurity.ts",
+      "filename": ".",
+      "source": {
+        "start": 1,
+        "end": 1,
+        "column": {
+          "start": 1,
+          "end": 43
+        }
+      },
+      "sink": {
+        "start": 1,
+        "end": 1,
+        "column": {
+          "start": 1,
+          "end": 43
+        },
+        "content": "expressJwt({ secret: \\"\\" + Math.random() })"
+      },
+      "parent_line_number": 1,
+      "snippet": "expressJwt({ secret: \\"\\" + Math.random() })",
+      "fingerprint": "eaae2a30ff6ed4568ddf01dd63a61387_0",
+      "old_fingerprint": "bc1db353c43740bf9d7b7d4bddbcddb4_0",
+      "code_extract": "expressJwt({ secret: \\"\\" + Math.random() })"
+    },
+    {
+      "cwe_ids": [
+        "525"
+      ],
+      "id": "javascript_express_jwt_not_revoked",
+      "title": "Unrevoked JWT detected.",
+      "description": "## Description\\nThe best practice caching policy is to revoke JWTs especially when these contain senstitive information.\\n\\n## Remediations\\n✅ Ensure JWTs are short-lived by revoking them\\n\\n\`\`\`javascript\\nexpressjwt({\\n  ...\\n  isRevoked: this.customRevokeCall(),\\n  ...\\n})\\n\`\`\`\\n\\n## Resources\\n- [ExpressJWT documentation on revoking tokens](https://github.com/auth0/express-jwt#revoked-tokens)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/javascript_express_jwt_not_revoked",
+      "line_number": 2,
+      "full_filename": "/tmp/bearer-scan/insecurity.ts",
+      "filename": ".",
+      "source": {
+        "start": 2,
+        "end": 2,
+        "column": {
+          "start": 30,
+          "end": 79
+        }
+      },
+      "sink": {
+        "start": 2,
+        "end": 2,
+        "column": {
+          "start": 30,
+          "end": 79
+        },
+        "content": "expressjwt({ secret: \\"\\" + Math.random() } as any)"
+      },
+      "parent_line_number": 2,
+      "snippet": "expressjwt({ secret: \\"\\" + Math.random() } as any)",
+      "fingerprint": "eaae2a30ff6ed4568ddf01dd63a61387_1",
+      "old_fingerprint": "bc1db353c43740bf9d7b7d4bddbcddb4_1",
+      "code_extract": "export const denyAll = () => expressjwt({ secret: \\"\\" + Math.random() } as any)"
+    }
+  ]
+}"
+`;
+
 exports[`javascript_express_jwt_not_revoked ok_express_jwt_revoked 1`] = `"{}"`;

--- a/tests/javascript/express/jwt_not_revoked/test.js
+++ b/tests/javascript/express/jwt_not_revoked/test.js
@@ -3,17 +3,19 @@ const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
 
 describe(ruleId, () => {
   const invoke = createInvoker(ruleId, ruleFile, testBase)
-  
 
   test("express_jwt_not_revoked", () => {
     const testCase = "express_jwt_not_revoked.js"
-    expect(invoke(testCase)).toMatchSnapshot();
+    expect(invoke(testCase)).toMatchSnapshot()
   })
-  
 
   test("ok_express_jwt_revoked", () => {
     const testCase = "ok_express_jwt_revoked.js"
-    expect(invoke(testCase)).toMatchSnapshot();
+    expect(invoke(testCase)).toMatchSnapshot()
   })
-  
+
+  test("insecurity_express_jwt_revoked", () => {
+    const testCase = "insecurity.ts"
+    expect(invoke(testCase)).toMatchSnapshot()
+  })
 })

--- a/tests/javascript/express/jwt_not_revoked/testdata/insecurity.ts
+++ b/tests/javascript/express/jwt_not_revoked/testdata/insecurity.ts
@@ -1,0 +1,2 @@
+expressJwt({ secret: "" + Math.random() })
+export const denyAll = () => expressjwt({ secret: "" + Math.random() } as any)


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

We were not taking into account  `as_expression` so the scope needs to be `result` instead of `cursor`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
