### PR TITLE
fix: remove unwanted semicolon in ruby datatype rule

### DIFF
--- a/rules/javascript/shared/common/datatype.yml
+++ b/rules/javascript/shared/common/datatype.yml
@@ -3,7 +3,7 @@ languages:
   - javascript
 sanitizer: javascript_shared_common_datatype_sanitizer
 patterns:
-  - pattern: $<DATA_TYPE>;
+  - pattern: $<DATA_TYPE>
     filters:
       - variable: DATA_TYPE
         detection: datatype

--- a/rules/ruby/shared/common/datatype.yml
+++ b/rules/ruby/shared/common/datatype.yml
@@ -3,7 +3,7 @@ languages:
   - ruby
 sanitizer: ruby_shared_common_datatype_sanitizer
 patterns:
-  - pattern: $<DATA_TYPE>;
+  - pattern: $<DATA_TYPE>
     filters:
       - variable: DATA_TYPE
         detection: datatype


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Removes an unwanted semicolon that was causing the shared Ruby datatype rule to fail in older CLI versions.

Also removes the semicolon from the Javascript rule - this has no functional effect but is done for consistency with not using semicolons in JS rules.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
