### PR TITLE
fix(javascript): add fallback for html user input sanitizer

### DIFF
--- a/rules/javascript/shared/third_parties/sanitize_html_sanitizer.yml
+++ b/rules/javascript/shared/third_parties/sanitize_html_sanitizer.yml
@@ -7,6 +7,8 @@ patterns:
   - sanitize($<!>$<_>$<...>)
   # DOMPurifier
   - sanitizeHtml($<!>$<_>$<...>)
+  # fallback
+  - sanitizer($<...>$<!>$<_>$<...>)
 metadata:
   description: "sanitize HTML sanitizer."
   id: javascript_shared_third_parties_sanitize_html_sanitizer

--- a/tests/javascript/lang/raw_html_using_user_input/testdata/ok.js
+++ b/tests/javascript/lang/raw_html_using_user_input/testdata/ok.js
@@ -1,6 +1,7 @@
 `<h1>#{sanitizeHtml(req.params.ok)}</h1>`
 
 doT.compile(sanitizeHtml(req.params.ok), {})
+doT.compile(sanitizer({ option: true }, req.params.ok), {})
 
 ejs.compile(sanitizeHtml(req.params.ok), {})
 


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds `sanitizer(...)` as a fallback for Javascript HTML user input. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
