### PR TITLE
feat: add cloud AI code suggestion flag

### DIFF
--- a/rules/go/gorilla/insecure_cookie.yml
+++ b/rules/go/gorilla/insecure_cookie.yml
@@ -106,3 +106,4 @@ metadata:
     - 614
   id: go_gorilla_insecure_cookie
   documentation_url: https://docs.bearer.com/reference/rules/go_gorilla_insecure_cookie
+  cloud_code_suggestions: true

--- a/rules/go/lang/information_leakage.yml
+++ b/rules/go/lang/information_leakage.yml
@@ -41,3 +41,4 @@ metadata:
     - 209
   id: go_lang_information_leakage
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_information_leakage
+  cloud_code_suggestions: true

--- a/rules/go/lang/logger.yml
+++ b/rules/go/lang/logger.yml
@@ -46,3 +46,4 @@ metadata:
     - 532
   id: go_lang_logger
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_logger
+  cloud_code_suggestions: true

--- a/rules/go/lang/weak_hash_md5.yml
+++ b/rules/go/lang/weak_hash_md5.yml
@@ -59,3 +59,4 @@ metadata:
     - 328
   id: go_lang_weak_hash_md5
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_weak_hash_md5
+  cloud_code_suggestions: true

--- a/rules/go/lang/weak_hash_sha1.yml
+++ b/rules/go/lang/weak_hash_sha1.yml
@@ -59,3 +59,4 @@ metadata:
     - 328
   id: go_lang_weak_hash_sha1
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_weak_hash_sha1
+  cloud_code_suggestions: true

--- a/rules/go/lang/weak_password_encryption_md5.yml
+++ b/rules/go/lang/weak_password_encryption_md5.yml
@@ -48,3 +48,4 @@ metadata:
     - 328
   id: go_lang_weak_password_encryption_md5
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_weak_password_encryption_md5
+  cloud_code_suggestions: true

--- a/rules/go/lang/weak_password_encryption_sha1.yml
+++ b/rules/go/lang/weak_password_encryption_sha1.yml
@@ -48,3 +48,4 @@ metadata:
     - 328
   id: go_lang_weak_password_encryption_sha1
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_weak_password_encryption_sha1
+  cloud_code_suggestions: true

--- a/rules/java/lang/cookie_missing_http_only.yml
+++ b/rules/java/lang/cookie_missing_http_only.yml
@@ -49,3 +49,4 @@ metadata:
     - 614
   id: java_lang_cookie_missing_http_only
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_cookie_missing_http_only
+  cloud_code_suggestions: true

--- a/rules/java/lang/cookie_missing_secure.yml
+++ b/rules/java/lang/cookie_missing_secure.yml
@@ -47,3 +47,4 @@ metadata:
     - 614
   id: java_lang_cookie_missing_secure
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_cookie_missing_secure
+  cloud_code_suggestions: true

--- a/rules/java/lang/file_permission_others.yml
+++ b/rules/java/lang/file_permission_others.yml
@@ -38,3 +38,4 @@ metadata:
     - 732
   id: "java_lang_file_permission_others"
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_file_permission_others
+  cloud_code_suggestions: true

--- a/rules/java/lang/information_leakage.yml
+++ b/rules/java/lang/information_leakage.yml
@@ -57,3 +57,4 @@ metadata:
     - 209
   id: java_lang_information_leakage
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_information_leakage
+  cloud_code_suggestions: true

--- a/rules/java/lang/insecure_cookie.yml
+++ b/rules/java/lang/insecure_cookie.yml
@@ -49,3 +49,4 @@ metadata:
     - 614
   id: java_lang_insecure_cookie
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_insecure_cookie
+  cloud_code_suggestions: true

--- a/rules/java/lang/logger.yml
+++ b/rules/java/lang/logger.yml
@@ -49,3 +49,4 @@ metadata:
     - 532
   id: "java_lang_logger"
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_logger
+  cloud_code_suggestions: true

--- a/rules/java/lang/missing_integrity_check.yml
+++ b/rules/java/lang/missing_integrity_check.yml
@@ -34,3 +34,4 @@ metadata:
     - 353
   id: java_lang_missing_integrity_check
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_missing_integrity_check
+  cloud_code_suggestions: true

--- a/rules/java/lang/rsa_no_padding.yml
+++ b/rules/java/lang/rsa_no_padding.yml
@@ -29,3 +29,4 @@ metadata:
     - 780
   id: "java_lang_rsa_no_padding"
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_rsa_no_padding
+  cloud_code_suggestions: true

--- a/rules/java/lang/weak_encryption_des.yml
+++ b/rules/java/lang/weak_encryption_des.yml
@@ -55,3 +55,4 @@ metadata:
     - 327
   id: java_lang_weak_encryption_des
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_weak_encryption_des
+  cloud_code_suggestions: true

--- a/rules/java/lang/weak_hash_md5.yml
+++ b/rules/java/lang/weak_hash_md5.yml
@@ -51,3 +51,4 @@ metadata:
     - 327
   id: java_lang_weak_hash_md5
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_weak_hash_md5
+  cloud_code_suggestions: true

--- a/rules/java/lang/weak_hash_sha1.yml
+++ b/rules/java/lang/weak_hash_sha1.yml
@@ -51,3 +51,4 @@ metadata:
     - 327
   id: java_lang_weak_hash_sha1
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_weak_hash_sha1
+  cloud_code_suggestions: true

--- a/rules/java/lang/weak_password_encryption_des.yml
+++ b/rules/java/lang/weak_password_encryption_des.yml
@@ -47,3 +47,4 @@ metadata:
     - 916
   id: java_lang_weak_password_encryption_des
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_weak_password_encryption_des
+  cloud_code_suggestions: true

--- a/rules/java/lang/weak_password_hash_md5.yml
+++ b/rules/java/lang/weak_password_hash_md5.yml
@@ -45,3 +45,4 @@ metadata:
     - 916
   id: java_lang_weak_password_hash_md5
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_weak_password_hash_md5
+  cloud_code_suggestions: true

--- a/rules/java/lang/weak_password_hash_sha1.yml
+++ b/rules/java/lang/weak_password_hash_sha1.yml
@@ -45,3 +45,4 @@ metadata:
     - 916
   id: java_lang_weak_password_hash_sha1
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_weak_password_hash_sha1
+  cloud_code_suggestions: true

--- a/rules/javascript/express/default_cookie_config.yml
+++ b/rules/javascript/express/default_cookie_config.yml
@@ -114,3 +114,4 @@ metadata:
     - 522
   id: javascript_express_default_cookie_config
   documentation_url: https://docs.bearer.com/reference/rules/javascript_express_default_cookie_config
+  cloud_code_suggestions: true

--- a/rules/javascript/express/exposed_dir_listing.yml
+++ b/rules/javascript/express/exposed_dir_listing.yml
@@ -18,3 +18,4 @@ metadata:
     - 548
   id: "javascript_express_exposed_dir_listing"
   documentation_url: https://docs.bearer.com/reference/rules/javascript_express_exposed_dir_listing
+  cloud_code_suggestions: true

--- a/rules/javascript/express/external_resource.yml
+++ b/rules/javascript/express/external_resource.yml
@@ -32,3 +32,4 @@ metadata:
     - 706
   id: "javascript_express_external_resource"
   documentation_url: https://docs.bearer.com/reference/rules/javascript_express_external_resource
+  cloud_code_suggestions: true

--- a/rules/javascript/express/https_protocol_missing.yml
+++ b/rules/javascript/express/https_protocol_missing.yml
@@ -34,3 +34,4 @@ metadata:
     - 693
   id: javascript_express_https_protocol_missing
   documentation_url: https://docs.bearer.com/reference/rules/javascript_express_https_protocol_missing
+  cloud_code_suggestions: true

--- a/rules/javascript/express/insecure_allow_origin.yml
+++ b/rules/javascript/express/insecure_allow_origin.yml
@@ -50,3 +50,4 @@ metadata:
     - 346
   id: javascript_express_insecure_allow_origin
   documentation_url: https://docs.bearer.com/reference/rules/javascript_express_insecure_allow_origin
+  cloud_code_suggestions: true

--- a/rules/javascript/express/insecure_cookie.yml
+++ b/rules/javascript/express/insecure_cookie.yml
@@ -40,3 +40,4 @@ metadata:
     - 614
   id: javascript_express_insecure_cookie
   documentation_url: https://docs.bearer.com/reference/rules/javascript_express_insecure_cookie
+  cloud_code_suggestions: true

--- a/rules/javascript/express/reduce_fingerprint.yml
+++ b/rules/javascript/express/reduce_fingerprint.yml
@@ -43,3 +43,4 @@ metadata:
     - 693
   id: javascript_express_reduce_fingerprint
   documentation_url: https://docs.bearer.com/reference/rules/javascript_express_reduce_fingerprint
+  cloud_code_suggestions: true

--- a/rules/javascript/express/ui_redress.yml
+++ b/rules/javascript/express/ui_redress.yml
@@ -45,3 +45,4 @@ metadata:
     - 1021
   id: "javascript_express_ui_redress"
   documentation_url: https://docs.bearer.com/reference/rules/javascript_express_ui_redress
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/exception.yml
+++ b/rules/javascript/lang/exception.yml
@@ -61,3 +61,4 @@ metadata:
     - 210
   id: javascript_lang_exception
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_exception
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/jwt_weak_encryption.yml
+++ b/rules/javascript/lang/jwt_weak_encryption.yml
@@ -29,3 +29,4 @@ metadata:
     - 327
   id: javascript_lang_jwt_weak_encryption
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_jwt_weak_encryption
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/logger.yml
+++ b/rules/javascript/lang/logger.yml
@@ -98,3 +98,4 @@ metadata:
     - 532
   id: "javascript_lang_logger"
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_logger
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/weak_encryption_des.yml
+++ b/rules/javascript/lang/weak_encryption_des.yml
@@ -48,3 +48,4 @@ metadata:
     - 327
   id: javascript_lang_weak_encryption_des
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_weak_encryption
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/weak_encryption_rc4.yml
+++ b/rules/javascript/lang/weak_encryption_rc4.yml
@@ -48,3 +48,4 @@ metadata:
     - 327
   id: javascript_lang_weak_encryption_rc4
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_weak_encryption_rc4
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/weak_hash_md5.yml
+++ b/rules/javascript/lang/weak_hash_md5.yml
@@ -119,3 +119,4 @@ metadata:
     - 328
   id: javascript_lang_weak_hash_md5
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_weak_hash_md5
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/weak_hash_sha1.yml
+++ b/rules/javascript/lang/weak_hash_sha1.yml
@@ -92,3 +92,4 @@ metadata:
     - 328
   id: javascript_lang_weak_hash_sha1
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_weak_hash_sha1
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/weak_password_encryption_des.yml
+++ b/rules/javascript/lang/weak_password_encryption_des.yml
@@ -42,3 +42,4 @@ metadata:
     - 327
   id: javascript_lang_weak_password_encryption_des
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_weak_password_encryption_des
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/weak_password_encryption_rc4.yml
+++ b/rules/javascript/lang/weak_password_encryption_rc4.yml
@@ -42,3 +42,4 @@ metadata:
     - 327
   id: javascript_lang_weak_password_encryption_rc4
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_weak_password_encryption_rc4
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/weak_password_hash_argon2.yml
+++ b/rules/javascript/lang/weak_password_hash_argon2.yml
@@ -63,3 +63,4 @@ metadata:
     - 916
   id: javascript_lang_weak_password_hash_argon2
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_weak_password_hash_argon2
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/weak_password_hash_md5.yml
+++ b/rules/javascript/lang/weak_password_hash_md5.yml
@@ -95,3 +95,4 @@ metadata:
     - 328
   id: javascript_lang_weak_password_hash_md5
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_weak_password_hash_md5
+  cloud_code_suggestions: true

--- a/rules/javascript/lang/weak_password_hash_sha1.yml
+++ b/rules/javascript/lang/weak_password_hash_sha1.yml
@@ -73,3 +73,4 @@ metadata:
     - 328
   id: javascript_lang_weak_password_hash_sha1
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_weak_password_hash_sha1
+  cloud_code_suggestions: true

--- a/rules/javascript/react/google_analytics.yml
+++ b/rules/javascript/react/google_analytics.yml
@@ -28,3 +28,4 @@ metadata:
     - 201
   id: "javascript_react_google_analytics"
   documentation_url: https://docs.bearer.com/reference/rules/javascript_react_google_analytics
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/airbrake.yml
+++ b/rules/javascript/third_parties/airbrake.yml
@@ -46,3 +46,4 @@ metadata:
   associated_recipe: Airbrake
   id: javascript_third_parties_airbrake
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_airbrake
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/algolia.yml
+++ b/rules/javascript/third_parties/algolia.yml
@@ -69,3 +69,4 @@ metadata:
   associated_recipe: Algolia
   id: javascript_third_parties_algolia
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_algolia
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/bugsnag.yml
+++ b/rules/javascript/third_parties/bugsnag.yml
@@ -81,3 +81,4 @@ metadata:
   associated_recipe: Bugsnag
   id: javascript_third_parties_bugsnag
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_bugsnag
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/datadog.yml
+++ b/rules/javascript/third_parties/datadog.yml
@@ -57,3 +57,4 @@ metadata:
   associated_recipe: Datadog
   id: javascript_third_parties_datadog
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_datadog
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/datadog_browser.yml
+++ b/rules/javascript/third_parties/datadog_browser.yml
@@ -27,3 +27,4 @@ metadata:
   associated_recipe: Datadog
   id: javascript_third_parties_datadog_browser
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_datadog_browser
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/dom_purify.yml
+++ b/rules/javascript/third_parties/dom_purify.yml
@@ -48,3 +48,4 @@ metadata:
     - 79
   id: javascript_third_parties_dom_purify
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_dom_purify
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/dynamodb_query_injection.yml
+++ b/rules/javascript/third_parties/dynamodb_query_injection.yml
@@ -71,3 +71,4 @@ metadata:
     - 89
   id: "javascript_third_parties_dynamodb_query_injection"
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_dynamodb_query_injection
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/elasticsearch.yml
+++ b/rules/javascript/third_parties/elasticsearch.yml
@@ -31,3 +31,4 @@ metadata:
     - 201
   id: javascript_third_parties_elasticsearch
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_elasticsearch
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/google_analytics.yml
+++ b/rules/javascript/third_parties/google_analytics.yml
@@ -39,3 +39,4 @@ metadata:
     - 201
   id: javascript_third_parties_google_analytics
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_google_analytics
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/google_tag_manager.yml
+++ b/rules/javascript/third_parties/google_tag_manager.yml
@@ -51,3 +51,4 @@ metadata:
     - 201
   id: javascript_third_parties_google_tag_manager
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_google_tag_manager
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/honeybadger.yml
+++ b/rules/javascript/third_parties/honeybadger.yml
@@ -47,3 +47,4 @@ metadata:
     - 201
   id: javascript_third_parties_honeybadger
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_honeybadger
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/new_relic.yml
+++ b/rules/javascript/third_parties/new_relic.yml
@@ -68,3 +68,4 @@ metadata:
     - 201
   id: "javascript_third_parties_new_relic"
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_new_relic
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/open_telemetry.yml
+++ b/rules/javascript/third_parties/open_telemetry.yml
@@ -41,3 +41,4 @@ metadata:
     - 201
   id: javascript_third_parties_open_telemetry
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_open_telemetry
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/openai.yml
+++ b/rules/javascript/third_parties/openai.yml
@@ -33,3 +33,4 @@ metadata:
   associated_recipe: OpenAI
   id: javascript_third_parties_openai
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_openai
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/rollbar.yml
+++ b/rules/javascript/third_parties/rollbar.yml
@@ -46,3 +46,4 @@ metadata:
     - 201
   id: javascript_third_parties_rollbar
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_rollbar
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/segment.yml
+++ b/rules/javascript/third_parties/segment.yml
@@ -46,3 +46,4 @@ metadata:
   associated_recipe: Segment
   id: javascript_third_parties_segment
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_segment
+  cloud_code_suggestions: true

--- a/rules/javascript/third_parties/sentry.yml
+++ b/rules/javascript/third_parties/sentry.yml
@@ -53,3 +53,4 @@ metadata:
   associated_recipe: Sentry
   id: javascript_third_parties_sentry
   documentation_url: https://docs.bearer.com/reference/rules/javascript_third_parties_sentry
+  cloud_code_suggestions: true

--- a/rules/php/lang/cookies.yml
+++ b/rules/php/lang/cookies.yml
@@ -32,3 +32,4 @@ metadata:
     - 539
   id: php_lang_cookies
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_cookies
+  cloud_code_suggestions: true

--- a/rules/php/lang/exception.yml
+++ b/rules/php/lang/exception.yml
@@ -44,3 +44,4 @@ metadata:
     - 210
   id: php_lang_exception
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_exception
+  cloud_code_suggestions: true

--- a/rules/php/lang/information_leakage.yml
+++ b/rules/php/lang/information_leakage.yml
@@ -58,3 +58,4 @@ metadata:
     - 209
   id: php_lang_information_leakage
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_information_leakage
+  cloud_code_suggestions: true

--- a/rules/php/lang/insecure_cookie.yml
+++ b/rules/php/lang/insecure_cookie.yml
@@ -115,3 +115,4 @@ metadata:
     - 614
   id: php_lang_insecure_cookie
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_insecure_cookie
+  cloud_code_suggestions: true

--- a/rules/php/lang/logger.yml
+++ b/rules/php/lang/logger.yml
@@ -39,3 +39,4 @@ metadata:
     - 532
   id: php_lang_logger
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_logger
+  cloud_code_suggestions: true

--- a/rules/php/lang/phpinfo.yml
+++ b/rules/php/lang/phpinfo.yml
@@ -22,3 +22,4 @@ metadata:
     - 200
   id: php_lang_phpinfo
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_phpinfo
+  cloud_code_suggestions: true

--- a/rules/php/lang/ssl_verification.yml
+++ b/rules/php/lang/ssl_verification.yml
@@ -453,3 +453,4 @@ metadata:
     - 295
   id: php_lang_ssl_verification
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_ssl_verification
+  cloud_code_suggestions: true

--- a/rules/php/lang/ui_redress.yml
+++ b/rules/php/lang/ui_redress.yml
@@ -33,3 +33,4 @@ metadata:
     - 1021
   id: "php_lang_ui_redress"
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_ui_redress
+  cloud_code_suggestions: true

--- a/rules/php/lang/weak_hash_md.yml
+++ b/rules/php/lang/weak_hash_md.yml
@@ -90,3 +90,4 @@ metadata:
     - 327
   id: php_lang_weak_hash_md
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_weak_hash_md
+  cloud_code_suggestions: true

--- a/rules/php/lang/weak_hash_sha1.yml
+++ b/rules/php/lang/weak_hash_sha1.yml
@@ -90,3 +90,4 @@ metadata:
     - 327
   id: php_lang_weak_hash_sha1
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_weak_hash_sha1
+  cloud_code_suggestions: true

--- a/rules/php/lang/weak_password_hash_md.yml
+++ b/rules/php/lang/weak_password_hash_md.yml
@@ -65,3 +65,4 @@ metadata:
     - 916
   id: php_lang_weak_password_hash_md
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_weak_password_hash_md
+  cloud_code_suggestions: true

--- a/rules/php/lang/weak_password_hash_sha1.yml
+++ b/rules/php/lang/weak_password_hash_sha1.yml
@@ -65,3 +65,4 @@ metadata:
     - 916
   id: php_lang_weak_password_hash_sha1
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_weak_password_hash_sha1
+  cloud_code_suggestions: true

--- a/rules/php/symfony/cookies.yml
+++ b/rules/php/symfony/cookies.yml
@@ -38,3 +38,4 @@ metadata:
     - 539
   id: php_symfony_cookies
   documentation_url: https://docs.bearer.com/reference/rules/php_symfony_cookies
+  cloud_code_suggestions: true

--- a/rules/php/symfony/csrf_protection_disabled.yml
+++ b/rules/php/symfony/csrf_protection_disabled.yml
@@ -38,3 +38,4 @@ metadata:
     - 352
   id: php_symfony_csrf_protection_disabled
   documentation_url: https://docs.bearer.com/reference/rules/php_symfony_csrf_protection_disabled
+  cloud_code_suggestions: true

--- a/rules/php/symfony/insecure_cookie.yml
+++ b/rules/php/symfony/insecure_cookie.yml
@@ -123,3 +123,4 @@ metadata:
     - 614
   id: php_symfony_insecure_cookie
   documentation_url: https://docs.bearer.com/reference/rules/php_symfony_insecure_cookie
+  cloud_code_suggestions: true

--- a/rules/php/symfony/insecure_smtp.yml
+++ b/rules/php/symfony/insecure_smtp.yml
@@ -28,3 +28,4 @@ metadata:
     - 319
   id: php_symfony_insecure_smtp
   documentation_url: https://docs.bearer.com/reference/rules/php_symfony_insecure_smtp
+  cloud_code_suggestions: true

--- a/rules/php/symfony/permissive_regex_validation.yml
+++ b/rules/php/symfony/permissive_regex_validation.yml
@@ -86,3 +86,4 @@ metadata:
     - 625
   id: php_symfony_permissive_regex_validation
   documentation_url: https://docs.bearer.com/reference/rules/php_symfony_permissive_regex_validation
+  cloud_code_suggestions: true

--- a/rules/php/symfony/ui_redress.yml
+++ b/rules/php/symfony/ui_redress.yml
@@ -53,3 +53,4 @@ metadata:
     - 1021
   id: "php_symfony_ui_redress"
   documentation_url: https://docs.bearer.com/reference/rules/php_symfony_ui_redress
+  cloud_code_suggestions: true

--- a/rules/php/third_parties/logger.yml
+++ b/rules/php/third_parties/logger.yml
@@ -56,3 +56,4 @@ metadata:
     - 532
   id: php_third_parties_logger
   documentation_url: https://docs.bearer.com/reference/rules/php_third_parties_logger
+  cloud_code_suggestions: true

--- a/rules/python/lang/logger.yml
+++ b/rules/python/lang/logger.yml
@@ -43,3 +43,4 @@ metadata:
     - 532
   id: python_lang_logger
   documentation_url: https://docs.bearer.com/reference/rules/python_lang_logger
+  cloud_code_suggestions: true

--- a/rules/python/lang/weak_hash_md5.yml
+++ b/rules/python/lang/weak_hash_md5.yml
@@ -59,3 +59,4 @@ metadata:
     - 328
   id: python_lang_weak_hash_md5
   documentation_url: https://docs.bearer.com/reference/rules/python_lang_weak_hash_md5
+  cloud_code_suggestions: true

--- a/rules/python/lang/weak_hash_sha1.yml
+++ b/rules/python/lang/weak_hash_sha1.yml
@@ -59,3 +59,4 @@ metadata:
     - 328
   id: python_lang_weak_hash_sha1
   documentation_url: https://docs.bearer.com/reference/rules/python_lang_weak_hash_sha1
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/cookies.yml
+++ b/rules/ruby/lang/cookies.yml
@@ -61,3 +61,4 @@ metadata:
     - 539
   id: ruby_lang_cookies
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_cookies
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/exception.yml
+++ b/rules/ruby/lang/exception.yml
@@ -35,3 +35,4 @@ metadata:
     - 210
   id: ruby_lang_exception
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_exception
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/http_get_params.yml
+++ b/rules/ruby/lang/http_get_params.yml
@@ -79,3 +79,4 @@ metadata:
     - 598
   id: ruby_lang_http_get_params
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_http_get_params
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/logger.yml
+++ b/rules/ruby/lang/logger.yml
@@ -47,3 +47,4 @@ metadata:
     - 532
   id: ruby_lang_logger
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_logger
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/ssl_verification.yml
+++ b/rules/ruby/lang/ssl_verification.yml
@@ -41,3 +41,4 @@ metadata:
     - 295
   id: ruby_lang_ssl_verification
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_ssl_verification
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_encryption_blowfish.yml
+++ b/rules/ruby/lang/weak_encryption_blowfish.yml
@@ -92,3 +92,4 @@ metadata:
     - 326
   id: ruby_lang_weak_encryption_blowfish
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_blowfish
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_encryption_dsa.yml
+++ b/rules/ruby/lang/weak_encryption_dsa.yml
@@ -55,3 +55,4 @@ metadata:
     - 326
   id: ruby_lang_weak_encryption_dsa
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_dsa
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_encryption_rc4.yml
+++ b/rules/ruby/lang/weak_encryption_rc4.yml
@@ -55,3 +55,4 @@ metadata:
     - 326
   id: ruby_lang_weak_encryption_rc4
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_rc4
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_encryption_rsa.yml
+++ b/rules/ruby/lang/weak_encryption_rsa.yml
@@ -55,3 +55,4 @@ metadata:
     - 326
   id: ruby_lang_weak_encryption_rsa
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_encryption_rsa
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_hash_dss.yml
+++ b/rules/ruby/lang/weak_hash_dss.yml
@@ -106,3 +106,4 @@ metadata:
     - 328
   id: ruby_lang_weak_hash_dss
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_hash_dss
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_hash_md.yml
+++ b/rules/ruby/lang/weak_hash_md.yml
@@ -121,3 +121,4 @@ metadata:
     - 328
   id: ruby_lang_weak_hash_md
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_hash_md
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_hash_sha.yml
+++ b/rules/ruby/lang/weak_hash_sha.yml
@@ -122,3 +122,4 @@ metadata:
     - 328
   id: ruby_lang_weak_hash_sha
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_hash_sha
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_password_encryption_blowfish.yml
+++ b/rules/ruby/lang/weak_password_encryption_blowfish.yml
@@ -80,3 +80,4 @@ metadata:
     - 916
   id: ruby_lang_weak_password_encryption_blowfish
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_password_encryption_blowfish
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_password_encryption_dsa.yml
+++ b/rules/ruby/lang/weak_password_encryption_dsa.yml
@@ -53,3 +53,4 @@ metadata:
     - 916
   id: ruby_lang_weak_password_encryption_dsa
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_password_encryption_dsa
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_password_encryption_rc4.yml
+++ b/rules/ruby/lang/weak_password_encryption_rc4.yml
@@ -53,3 +53,4 @@ metadata:
     - 916
   id: ruby_lang_weak_password_encryption_rc4
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_password_encryption_rc4
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_password_encryption_rsa.yml
+++ b/rules/ruby/lang/weak_password_encryption_rsa.yml
@@ -51,3 +51,4 @@ metadata:
     - 916
   id: ruby_lang_weak_password_encryption_rsa
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_password_encryption_rsa
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_password_hash_dss.yml
+++ b/rules/ruby/lang/weak_password_hash_dss.yml
@@ -82,3 +82,4 @@ metadata:
     - 916
   id: ruby_lang_weak_password_hash_dss
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_password_hash_dss
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_password_hash_md.yml
+++ b/rules/ruby/lang/weak_password_hash_md.yml
@@ -92,3 +92,4 @@ metadata:
     - 916
   id: ruby_lang_weak_password_hash_md
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_password_hash_md
+  cloud_code_suggestions: true

--- a/rules/ruby/lang/weak_password_hash_sha.yml
+++ b/rules/ruby/lang/weak_password_hash_sha.yml
@@ -92,3 +92,4 @@ metadata:
     - 916
   id: ruby_lang_weak_password_hash_sha
   documentation_url: https://docs.bearer.com/reference/rules/ruby_lang_weak_password_hash_sha
+  cloud_code_suggestions: true

--- a/rules/ruby/rails/detailed_exceptions.yml
+++ b/rules/ruby/rails/detailed_exceptions.yml
@@ -61,3 +61,4 @@ metadata:
     - 209
   id: ruby_rails_detailed_exceptions
   documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_detailed_exceptions
+  cloud_code_suggestions: true

--- a/rules/ruby/rails/insecure_communication.yml
+++ b/rules/ruby/rails/insecure_communication.yml
@@ -29,3 +29,4 @@ metadata:
     - 319
   id: ruby_rails_insecure_communication
   documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_communication
+  cloud_code_suggestions: true

--- a/rules/ruby/rails/insecure_disabling_of_callback.yml
+++ b/rules/ruby/rails/insecure_disabling_of_callback.yml
@@ -34,3 +34,4 @@ metadata:
     - 284
   id: ruby_rails_insecure_disabling_of_callback
   documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_disabling_of_callback
+  cloud_code_suggestions: true

--- a/rules/ruby/rails/insecure_smtp.yml
+++ b/rules/ruby/rails/insecure_smtp.yml
@@ -37,3 +37,4 @@ metadata:
     - 319
   id: ruby_rails_insecure_smtp
   documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_insecure_smtp
+  cloud_code_suggestions: true

--- a/rules/ruby/rails/logger.yml
+++ b/rules/ruby/rails/logger.yml
@@ -45,3 +45,4 @@ metadata:
     - 532
   id: ruby_rails_logger
   documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_logger
+  cloud_code_suggestions: true

--- a/rules/ruby/rails/password_length.yml
+++ b/rules/ruby/rails/password_length.yml
@@ -58,3 +58,4 @@ metadata:
     - 521
   id: ruby_rails_password_length
   documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_password_length
+  cloud_code_suggestions: true

--- a/rules/ruby/rails/permissive_regex_validation.yml
+++ b/rules/ruby/rails/permissive_regex_validation.yml
@@ -53,3 +53,4 @@ metadata:
     - 625
   id: ruby_rails_permissive_regex_validation
   documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_permissive_regex_validation
+  cloud_code_suggestions: true

--- a/rules/ruby/rails/session.yml
+++ b/rules/ruby/rails/session.yml
@@ -33,3 +33,4 @@ metadata:
     - 315
   id: ruby_rails_session
   documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session
+  cloud_code_suggestions: true

--- a/rules/ruby/rails/session_with_httponly_disabled.yml
+++ b/rules/ruby/rails/session_with_httponly_disabled.yml
@@ -26,3 +26,4 @@ metadata:
     - 1004
   id: ruby_rails_session_with_httponly_disabled
   documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_session_with_httponly_disabled
+  cloud_code_suggestions: true

--- a/rules/ruby/rails/unsafe_cookie_serialization_strategy.yml
+++ b/rules/ruby/rails/unsafe_cookie_serialization_strategy.yml
@@ -33,3 +33,4 @@ metadata:
     - 94
   id: ruby_rails_unsafe_cookie_serialization_strategy
   documentation_url: https://docs.bearer.com/reference/rules/ruby_rails_unsafe_cookie_serialization_strategy
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/airbrake.yml
+++ b/rules/ruby/third_parties/airbrake.yml
@@ -74,3 +74,4 @@ metadata:
   associated_recipe: Airbrake
   id: ruby_third_parties_airbrake
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_airbrake
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/algolia.yml
+++ b/rules/ruby/third_parties/algolia.yml
@@ -47,3 +47,4 @@ metadata:
   associated_recipe: Algolia
   id: ruby_third_parties_algolia
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_algolia
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/bigquery.yml
+++ b/rules/ruby/third_parties/bigquery.yml
@@ -86,3 +86,4 @@ metadata:
   associated_recipe: Google Cloud BigQuery
   id: ruby_third_parties_bigquery
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bigquery
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/bugsnag.yml
+++ b/rules/ruby/third_parties/bugsnag.yml
@@ -54,3 +54,4 @@ metadata:
   associated_recipe: Bugsnag
   id: ruby_third_parties_bugsnag
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_bugsnag
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/clickhouse.yml
+++ b/rules/ruby/third_parties/clickhouse.yml
@@ -36,3 +36,4 @@ metadata:
   associated_recipe: ClickHouse
   id: ruby_third_parties_clickhouse
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_clickhouse
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/datadog.yml
+++ b/rules/ruby/third_parties/datadog.yml
@@ -55,3 +55,4 @@ metadata:
   associated_recipe: Datadog
   id: ruby_third_parties_datadog
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_datadog
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/elasticsearch.yml
+++ b/rules/ruby/third_parties/elasticsearch.yml
@@ -56,3 +56,4 @@ metadata:
   associated_recipe: Elasticsearch
   id: ruby_third_parties_elasticsearch
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_elasticsearch
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/google_analytics.yml
+++ b/rules/ruby/third_parties/google_analytics.yml
@@ -42,3 +42,4 @@ metadata:
   associated_recipe: Google Analytics
   id: ruby_third_parties_google_analytics
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_analytics
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/google_dataflow.yml
+++ b/rules/ruby/third_parties/google_dataflow.yml
@@ -151,3 +151,4 @@ metadata:
     - 201
   id: ruby_third_parties_google_dataflow
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_google_dataflow
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/honeybadger.yml
+++ b/rules/ruby/third_parties/honeybadger.yml
@@ -48,3 +48,4 @@ metadata:
   associated_recipe: Honeybadger
   id: ruby_third_parties_honeybadger
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_honeybadger
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/new_relic.yml
+++ b/rules/ruby/third_parties/new_relic.yml
@@ -41,3 +41,4 @@ metadata:
   associated_recipe: New Relic
   id: ruby_third_parties_new_relic
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_new_relic
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/open_telemetry.yml
+++ b/rules/ruby/third_parties/open_telemetry.yml
@@ -58,3 +58,4 @@ metadata:
     - 201
   id: ruby_third_parties_open_telemetry
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_open_telemetry
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/rollbar.yml
+++ b/rules/ruby/third_parties/rollbar.yml
@@ -70,3 +70,4 @@ metadata:
   associated_recipe: Rollbar
   id: ruby_third_parties_rollbar
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_rollbar
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/scout_apm.yml
+++ b/rules/ruby/third_parties/scout_apm.yml
@@ -34,3 +34,4 @@ metadata:
   associated_recipe: Scout APM
   id: ruby_third_parties_scout_apm
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_scout_apm
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/segment.yml
+++ b/rules/ruby/third_parties/segment.yml
@@ -43,3 +43,4 @@ metadata:
   associated_recipe: Segment
   id: ruby_third_parties_segment
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_segment
+  cloud_code_suggestions: true

--- a/rules/ruby/third_parties/sentry.yml
+++ b/rules/ruby/third_parties/sentry.yml
@@ -164,3 +164,4 @@ metadata:
   associated_recipe: Sentry
   id: ruby_third_parties_sentry
   documentation_url: https://docs.bearer.com/reference/rules/ruby_third_parties_sentry
+  cloud_code_suggestions: true

--- a/scripts/rule_schema.jsonc
+++ b/scripts/rule_schema.jsonc
@@ -139,6 +139,9 @@
         },
         "associated_recipe": {
           "type": "string"
+        },
+        "cloud_code_suggestions": {
+          "type": "boolean"
         }
       },
       "required": [


### PR DESCRIPTION
## Description

Flag certain Bearer rules as eligible for code-based suggestions from the AI. This flag will be used internally by the Bearer Cloud, so it is not documented (yet?). 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
