### PR TITLE
fix(go): focus weak encryption library

### DIFF
--- a/rules/go/gosec/blocklist/cgi.yml
+++ b/rules/go/gosec/blocklist/cgi.yml
@@ -1,9 +1,9 @@
 patterns:
   - pattern: |
-      import "net/http/cgi"
+      import $<!>"net/http/cgi"
   - pattern: |
       import (
-        "net/http/cgi"
+        $<!>"net/http/cgi"
       )
 languages:
   - go

--- a/rules/go/gosec/blocklist/des.yml
+++ b/rules/go/gosec/blocklist/des.yml
@@ -1,9 +1,9 @@
 patterns:
   - pattern: |
-      import "crypto/des"
+      import $<!>"crypto/des"
   - pattern: |
       import (
-        "crypto/des"
+        $<!>"crypto/des"
       )
 languages:
   - go

--- a/rules/go/gosec/blocklist/md5.yml
+++ b/rules/go/gosec/blocklist/md5.yml
@@ -1,9 +1,9 @@
 patterns:
   - pattern: |
-      import "crypto/md5"
+      import $<!>"crypto/md5"
   - pattern: |
       import (
-        "crypto/md5"
+        $<!>"crypto/md5"
       )
 languages:
   - go

--- a/rules/go/gosec/blocklist/rc4.yml
+++ b/rules/go/gosec/blocklist/rc4.yml
@@ -1,9 +1,9 @@
 patterns:
   - pattern: |
-      import "crypto/rc4"
+      import $<!>"crypto/rc4"
   - pattern: |
       import (
-        "crypto/rc4"
+        $<!>"crypto/rc4"
       )
 languages:
   - go

--- a/rules/go/gosec/blocklist/sha1.yml
+++ b/rules/go/gosec/blocklist/sha1.yml
@@ -1,9 +1,9 @@
 patterns:
   - pattern: |
-      import "crypto/sha1"
+      import $<!>"crypto/sha1"
   - pattern: |
       import (
-        "crypto/sha1"
+        $<!>"crypto/sha1"
       )
 languages:
   - go

--- a/rules/go/gosec/leak/pprof_endpoint.yml
+++ b/rules/go/gosec/leak/pprof_endpoint.yml
@@ -1,8 +1,8 @@
 patterns:
-  - import "net/http/pprof"
+  - import $<!>"net/http/pprof"
   - pattern: |
       import (
-        $<_>"net/http/pprof"
+        $<!>"net/http/pprof"
       )
 languages:
   - go

--- a/tests/go/gosec/blocklist/cgi/__snapshots__/test.js.snap
+++ b/tests/go/gosec/blocklist/cgi/__snapshots__/test.js.snap
@@ -18,7 +18,7 @@ exports[`go_gosec_blocklist_cgi test 1`] = `
         "start": 3,
         "end": 3,
         "column": {
-          "start": 1,
+          "start": 8,
           "end": 22
         }
       },
@@ -26,13 +26,13 @@ exports[`go_gosec_blocklist_cgi test 1`] = `
         "start": 3,
         "end": 3,
         "column": {
-          "start": 1,
+          "start": 8,
           "end": 22
         },
-        "content": "import \\"net/http/cgi\\""
+        "content": "\\"net/http/cgi\\""
       },
       "parent_line_number": 3,
-      "snippet": "import \\"net/http/cgi\\"",
+      "snippet": "\\"net/http/cgi\\"",
       "fingerprint": "d44ba4fd1dac6349b308c573d7831ecc_0",
       "old_fingerprint": "f4afdcd85f5f01a0d80ee3f3337e2888_0",
       "code_extract": "import \\"net/http/cgi\\""
@@ -52,31 +52,31 @@ exports[`go_gosec_blocklist_cgi test 2 1`] = `
       "title": "Use of a Broken or Risky Cryptographic Algorithm",
       "description": "## Description\\n\\nUsing the \`net/http/cgi\` package in Go, especially with versions prior to 1.6.3, exposes the application to the Httpoxy attack, a vulnerability identified as CVE-2016-5386. This vulnerability arises from the way CGI and FastCGI protocols handle certain environment variables, which can be manipulated to intercept and redirect outgoing HTTP requests made by the web application.\\n\\n## Remediations\\n\\n✅ Update Go Version\\n\\nEnsure you are using a version of Go that is 1.6.3 or later, where this vulnerability is patched.\\n\\n\`\`\`sh\\n# Check Go version and update if necessary\\ngo version\\n# Follow Go's update instructions if your version is < 1.6.3\\n\`\`\`\\n\\n✅ Use Alternative Packages\\n\\nRefrain from using CGI where possible. Utilize alternative packages and methods to handle HTTP requests which do not rely on the CGI protocol.\\n\\n\`\`\`go\\n// Use the standard net/http package instead\\nimport \\"net/http\\"\\n\`\`\`\\n\\n❌ Don't Use \`net/http/cgi\` in Older Versions\\n\\nDo not use the \`net/http/cgi\` package if you are operating on Go versions older than 1.6.3 as they are susceptible to the Httpoxy vulnerability.\\n\\n\`\`\`go\\n// This import is vulnerable to Httpoxy in Go < 1.6.3\\nimport \\"net/http/cgi\\"\\n\`\`\`\\n\\n❌ Avoid Exposing Environment Variables\\n\\nEnsure that the environment variables such as \`HTTP_PROXY\` are not being exposed unintentionally, as this can be leveraged for Httpoxy attacks.\\n\\n## Resources\\n\\n- [CVE-2016-5386 Detail](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5386)\\n- [Httpoxy.org](https://httpoxy.org/)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/go_gosec_blocklist_cgi",
-      "line_number": 3,
+      "line_number": 4,
       "full_filename": "/tmp/bearer-scan/main2.go",
       "filename": ".",
       "source": {
-        "start": 3,
-        "end": 5,
+        "start": 4,
+        "end": 4,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 7,
+          "end": 21
         }
       },
       "sink": {
-        "start": 3,
-        "end": 5,
+        "start": 4,
+        "end": 4,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 7,
+          "end": 21
         },
-        "content": "import (\\n\\tcgi2 \\"net/http/cgi\\"\\n)"
+        "content": "\\"net/http/cgi\\""
       },
-      "parent_line_number": 3,
-      "snippet": "import (\\n\\tcgi2 \\"net/http/cgi\\"\\n)",
+      "parent_line_number": 4,
+      "snippet": "\\"net/http/cgi\\"",
       "fingerprint": "d44ba4fd1dac6349b308c573d7831ecc_0",
       "old_fingerprint": "08ab0d9c254c63555f4b1118aaa6548a_0",
-      "code_extract": "import (\\n\\tcgi2 \\"net/http/cgi\\"\\n)"
+      "code_extract": "\\tcgi2 \\"net/http/cgi\\""
     }
   ]
 }"

--- a/tests/go/gosec/blocklist/des/__snapshots__/test.js.snap
+++ b/tests/go/gosec/blocklist/des/__snapshots__/test.js.snap
@@ -11,31 +11,31 @@ exports[`go_gosec_blocklist_des test 1`] = `
       "title": "Use of a Broken or Risky Cryptographic Algorithm",
       "description": "## Description\\n\\nThe Data Encryption Standard (DES) is an outdated symmetric-key algorithm for encryption. Officially deemed insecure and no longer recommended for use, DES was withdrawn by the National Institute of Standards and Technology (NIST) as a standard in 2005, primarily because of its 56-bit key size, which is vulnerable to brute-force attacks.\\n\\n## Remediation\\n\\nTo ensure the confidentiality and integrity of sensitive data, it is crucial to utilize a modern and secure encryption algorithm. The use of Advanced Encryption Standard (AES) with a key size of 256 bits (AES-256) is recommended for its strong security properties and widespread acceptance as a replacement for DES.\\n\\n✅ Implement AES-256 for Strong Encryption\\n\\n\`\`\`go\\n// Use AES-256 for secure encryption by initializing a 32-byte key for AES-256\\nkey := make([]byte, 32)\\nif _, err := io.ReadFull(rand.Reader, key); err != nil {\\n  log.Fatal(err)\\n}\\n\\n// Create a new cipher block from the key\\nblockCipher, err := aes.NewCipher(key)\\nif err != nil {\\n  log.Fatal(err)\\n}\\n\\n// Use Galois/Counter Mode (GCM) for both encryption and decryption\\naead, err := cipher.NewGCM(blockCipher)\\nif err != nil {\\n  log.Fatal(err)\\n}\\n\\nvar encrypted = []byte{}\\nvar nonce = []byte{}\\n\\n// Encrypt a message with AES-256 using GCM\\n{\\n  msg := []byte(\\"Some secret message\\")\\n  // Ensure nonces are unique for each encryption to maintain security\\n  nonce = make([]byte, 12)\\n  if _, err := io.ReadFull(rand.Reader, nonce); err != nil {\\n    log.Fatal(err)\\n  }\\n  encrypted = aead.Seal(nil, nonce, msg, nil)\\n}\\n\\n// Decrypt the message securely\\n{\\n  msg, err := aead.Open(nil, nonce, encrypted, nil)\\n  if err != nil {\\n    log.Fatal(err)\\n  }\\n  fmt.Printf(\\"Decrypted: %s\\\\n\\", msg)\\n}\\n\`\`\`\\n\\n❌ Do Not Use Deprecated Algorithms\\nAvoid using deprecated cryptographic algorithms such as DES, as they do not provide adequate security against modern threats and attacks.\\n\\n## Resources\\n\\n- [NIST Recommendations](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final)\\n- [AES-256 Encryption](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/go_gosec_blocklist_des",
-      "line_number": 3,
+      "line_number": 4,
       "full_filename": "/tmp/bearer-scan/main.go",
       "filename": ".",
       "source": {
-        "start": 3,
-        "end": 6,
+        "start": 4,
+        "end": 4,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 2,
+          "end": 14
         }
       },
       "sink": {
-        "start": 3,
-        "end": 6,
+        "start": 4,
+        "end": 4,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 2,
+          "end": 14
         },
-        "content": "import (\\n\\t\\"crypto/des\\"\\n\\t\\"fmt\\"\\n)"
+        "content": "\\"crypto/des\\""
       },
-      "parent_line_number": 3,
-      "snippet": "import (\\n\\t\\"crypto/des\\"\\n\\t\\"fmt\\"\\n)",
+      "parent_line_number": 4,
+      "snippet": "\\"crypto/des\\"",
       "fingerprint": "5701c2af30f4ca2aaf2cb0bff61be1be_0",
       "old_fingerprint": "c8850e419b899cc93c57917fbacacbf4_0",
-      "code_extract": "import (\\n\\t\\"crypto/des\\"\\n\\t\\"fmt\\"\\n)"
+      "code_extract": "\\t\\"crypto/des\\""
     }
   ]
 }"

--- a/tests/go/gosec/blocklist/md5/__snapshots__/test.js.snap
+++ b/tests/go/gosec/blocklist/md5/__snapshots__/test.js.snap
@@ -11,31 +11,31 @@ exports[`go_gosec_blocklist_md5 test 1`] = `
       "title": "Use of a Broken or Risky Cryptographic Algorithm",
       "description": "## Description\\n\\nMD5 is a widely used cryptographic hash function that produces a 128-bit (16-byte) hash value. It's commonly used to check the integrity of files. However, MD5 is not collision-resistant; this means that different inputs may produce the same output hash. MD5's vulnerabilities and the feasibility of collision attacks have rendered it obsolete for security-related purposes, particularly digital signatures, SSL certificates, and cryptographic message authentication.\\n\\n## Remediation\\n\\nGiven the vulnerabilities of MD5, it is highly recommended to switch to more secure hashing algorithms. For hashing purposes that do not involve passwords, such as verifying file integrity or generating unique identifiers, SHA-3 or BLAKE2 can be used due to their stronger cryptographic properties.\\n\\n✅ Use SHA-3 or BLAKE2 for General Hashing Needs\\n\\n\`\`\`go\\n// BLAKE2 is a cryptographic hash function faster than MD5, SHA-1, and SHA-2, and as secure as the latest standard SHA-3\\nfileContents := []byte(\\"some file contents to create hash for\\")\\nblake2bHasher, err := blake2b.New512(nil)\\nif err != nil {\\n  log.Fatal(err)\\n}\\nhashedValue := blake2bHasher.Sum(fileContents)\\nfmt.Printf(\\"%s\\\\n\\", hex.EncodeToString(hashedValue))\\n\`\`\`\\n\\nFor password hashing, where the hash functions need to be slow to combat brute-force attacks, bcrypt or Argon2id should be used. These algorithms are designed to be computationally intensive to hash and verify, which helps protect against password cracking attempts.\\n\\n✅ Adopt bcrypt or Argon2id for Password Hashing\\n\\nThe bcrypt algorithm is a good choice for password hashing as it allows you to adjust the cost (computational complexity) and is widely supported. Argon2id is the winner of the Password Hashing Competition and offers a good balance between resistance to GPU cracking attacks and usability.\\n\\n## Resources\\n\\n- [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/go_gosec_blocklist_md5",
-      "line_number": 3,
+      "line_number": 4,
       "full_filename": "/tmp/bearer-scan/main.go",
       "filename": ".",
       "source": {
-        "start": 3,
-        "end": 6,
+        "start": 4,
+        "end": 4,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 2,
+          "end": 14
         }
       },
       "sink": {
-        "start": 3,
-        "end": 6,
+        "start": 4,
+        "end": 4,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 2,
+          "end": 14
         },
-        "content": "import (\\n\\t\\"crypto/md5\\"\\n\\t\\"fmt\\"\\n)"
+        "content": "\\"crypto/md5\\""
       },
-      "parent_line_number": 3,
-      "snippet": "import (\\n\\t\\"crypto/md5\\"\\n\\t\\"fmt\\"\\n)",
+      "parent_line_number": 4,
+      "snippet": "\\"crypto/md5\\"",
       "fingerprint": "eb186a281342cc12d763fe3c841dfc09_0",
       "old_fingerprint": "389be4fd1aecab117b4e71d6dc81e0fe_0",
-      "code_extract": "import (\\n\\t\\"crypto/md5\\"\\n\\t\\"fmt\\"\\n)"
+      "code_extract": "\\t\\"crypto/md5\\""
     }
   ]
 }"

--- a/tests/go/gosec/blocklist/rc4/__snapshots__/test.js.snap
+++ b/tests/go/gosec/blocklist/rc4/__snapshots__/test.js.snap
@@ -11,31 +11,31 @@ exports[`go_gosec_blocklist_rc4 test 1`] = `
       "title": "Use of a Broken or Risky Cryptographic Algorithm",
       "description": "## Description\\n\\nRC4 is a stream cipher that was once popular for its simplicity and speed in operation. However, extensive research over the years has revealed multiple vulnerabilities, rendering RC4 insecure in most contexts. Its weaknesses in key scheduling and the generation of non-random bytes have led to successful cryptanalysis and practical attacks, making it unsuitable for securing data.\\n\\n## Remediation\\n\\nWith the known vulnerabilities of RC4, it's essential to move to a more secure cipher. AES (Advanced Encryption Standard) is the recommended replacement because it has undergone extensive scrutiny and is considered secure against cryptanalysis.\\n\\n✅ Switch to AES-256 for Robust Encryption\\n\\n\`\`\`go\\n// 32 byte keys will set up AES-256, which is a secure block cipher that has become the industry standard for encryption.\\nkey := make([]byte, 32)\\nif _, err := io.ReadFull(rand.Reader, key); err != nil {\\n  log.Fatal(err)\\n}\\n\\nblockCipher, err := aes.NewCipher(key)\\nif err != nil {\\n  log.Fatal(err)\\n}\\n\\naead, err := cipher.NewGCM(blockCipher)\\nif err != nil {\\n  log.Fatal(err)\\n}\\n\\nvar encrypted = []byte{}\\nvar nonce = []byte{}\\n// Encryption routine\\n{\\n  msg := []byte(\\"Some secret message\\")\\n  // Note that the key must be rotated after every 2^32 uses of a single nonce-value to avoid cipher text repetition.\\n  nonce = make([]byte, 12)\\n  if _, err := io.ReadFull(rand.Reader, nonce); err != nil {\\n    log.Fatal(err)\\n  }\\n  encrypted = aead.Seal(nil, nonce, msg, nil)\\n}\\n\\n// Decryption routine\\n{\\n  msg, err := aead.Open(nil, nonce, encrypted, nil)\\n  if err != nil {\\n    log.Fatal(err)\\n  }\\n  fmt.Printf(\\"Decrypted: %s\\\\n\\", msg)\\n}\\n\`\`\`\\n\\nUsing AES-256 ensures that your encryption mechanism meets current security standards and is robust against known attacks. AES has been widely adopted across various industries and has proven its reliability over time.\\n\\n## Resources\\n\\n- [NIST Guidelines on Cryptography](https://csrc.nist.gov/publications/detail/sp/800-38a/final)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/go_gosec_blocklist_rc4",
-      "line_number": 3,
+      "line_number": 4,
       "full_filename": "/tmp/bearer-scan/main.go",
       "filename": ".",
       "source": {
-        "start": 3,
-        "end": 6,
+        "start": 4,
+        "end": 4,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 2,
+          "end": 14
         }
       },
       "sink": {
-        "start": 3,
-        "end": 6,
+        "start": 4,
+        "end": 4,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 2,
+          "end": 14
         },
-        "content": "import (\\n\\t\\"crypto/rc4\\"\\n\\t\\"fmt\\"\\n)"
+        "content": "\\"crypto/rc4\\""
       },
-      "parent_line_number": 3,
-      "snippet": "import (\\n\\t\\"crypto/rc4\\"\\n\\t\\"fmt\\"\\n)",
+      "parent_line_number": 4,
+      "snippet": "\\"crypto/rc4\\"",
       "fingerprint": "0fec54dd8724cf655550856999eb17fb_0",
       "old_fingerprint": "67002f96f906da879da606e636c13b8c_0",
-      "code_extract": "import (\\n\\t\\"crypto/rc4\\"\\n\\t\\"fmt\\"\\n)"
+      "code_extract": "\\t\\"crypto/rc4\\""
     }
   ]
 }"

--- a/tests/go/gosec/blocklist/sha1/__snapshots__/test.js.snap
+++ b/tests/go/gosec/blocklist/sha1/__snapshots__/test.js.snap
@@ -11,31 +11,31 @@ exports[`go_gosec_blocklist_sha1 test 1`] = `
       "title": "Use of a Broken or Risky Cryptographic Algorithm",
       "description": "## Description\\n\\nThe SHA-1 hashing algorithm is no longer considered secure against well-funded attackers. It is vulnerable to collision attacks, which means it's possible to generate two different inputs that result in the same SHA-1 hash, undermining the hash's uniqueness and security. Due to these vulnerabilities, it is advised to discontinue using SHA-1 for cryptographic security.\\n\\n## Remediation\\n\\nWhen choosing a hashing algorithm for cryptographic purposes, it's important to select one that is resistant to collisions and other attack vectors. SHA-3 and BLAKE2 are both excellent choices for non-password-based hashing requirements due to their strong cryptographic properties.\\n\\n✅ For General Hashing Needs, Use SHA-3 or BLAKE2\\n\\nChoose SHA-3 or BLAKE2 for their resistance to known hash attack vectors, ensuring the integrity and uniqueness of your data fingerprints.\\n\\n✅ For Password Hashing, Prefer bcrypt or Argon2id\\n\\nFor password hashing specifically, bcrypt or Argon2id are recommended. These algorithms are designed to be computationally intensive, which helps protect against brute-force attacks.\\n\\n❌ Discontinue Using SHA-1 for Security Purposes\\n\\nGiven its vulnerabilities, avoid using SHA-1 in any security context to prevent potential collision attacks.\\n\\nThe code snippet provided is unrelated to the hashing algorithms and seems to be a continuation of the previous examples for encryption with AES-256. Ensure your hashing and encryption strategies are correctly implemented as per their intended use-cases.\\n\\n## Resources\\n\\n- [OWASP Cryptographic Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)\\n- [NIST Policy on Hash Functions](https://csrc.nist.gov/projects/hash-functions)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/go_gosec_blocklist_sha1",
-      "line_number": 3,
+      "line_number": 4,
       "full_filename": "/tmp/bearer-scan/main.go",
       "filename": ".",
       "source": {
-        "start": 3,
-        "end": 6,
+        "start": 4,
+        "end": 4,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 2,
+          "end": 15
         }
       },
       "sink": {
-        "start": 3,
-        "end": 6,
+        "start": 4,
+        "end": 4,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 2,
+          "end": 15
         },
-        "content": "import (\\n\\t\\"crypto/sha1\\"\\n\\t\\"fmt\\"\\n)"
+        "content": "\\"crypto/sha1\\""
       },
-      "parent_line_number": 3,
-      "snippet": "import (\\n\\t\\"crypto/sha1\\"\\n\\t\\"fmt\\"\\n)",
+      "parent_line_number": 4,
+      "snippet": "\\"crypto/sha1\\"",
       "fingerprint": "c2e8f4129be45dc51a2f05ecb2a2c021_0",
       "old_fingerprint": "be80d15eca84c5e2caf79b59e5541bc9_0",
-      "code_extract": "import (\\n\\t\\"crypto/sha1\\"\\n\\t\\"fmt\\"\\n)"
+      "code_extract": "\\t\\"crypto/sha1\\""
     }
   ]
 }"

--- a/tests/go/gosec/leak/pprof_endpoint/__snapshots__/test.js.snap
+++ b/tests/go/gosec/leak/pprof_endpoint/__snapshots__/test.js.snap
@@ -11,31 +11,31 @@ exports[`go_gosec_leak_pprof_endpoint test 1`] = `
       "title": "Active debug code (pprof enabled)",
       "description": "## Description\\n\\nGo's standard library includes a profiling tool that can be enabled by importing \`net/http/pprof\`. This tool provides a \`/debug/pprof\` endpoint that exposes runtime profiling data over HTTP. When enabled in a production environment, it can present a significant security risk as it lacks authentication controls and can potentially leak sensitive information about the application's runtime state and environment.\\n\\n## Remediations\\n\\nTo prevent unintended exposure of profiling information:\\n\\n✅ Remove \`net/http/pprof\` in Production\\n\\nBefore deploying your application to a production environment, remove any import statements for \`net/http/pprof\` from your codebase. Ensure that the profiling endpoint is not available in the live environment.\\n\\n\`\`\`go\\n// +build !production\\n\\npackage main\\n\\nimport (\\n    _ \\"net/http/pprof\\" // Ensure this line is not present in your production builds\\n    \\"net/http\\"\\n)\\n\\nfunc main() {\\n    // ... your application code ...\\n\\n    // Start the server (omit the pprof import and handler in production)\\n    log.Println(http.ListenAndServe(\\"localhost:6060\\", nil))\\n}\\n\`\`\`\\n\\n✅ Conditional Compilation\\n\\nUse build tags to include profiling only in non-production builds.\\n\\n✅ Use Environment Configurations\\n\\nConfigure environment-specific settings to conditionally enable or disable the profiling endpoints.\\n\\n✅ Implement Authentication\\n\\nIf profiling is necessary in a controlled production scenario, secure the endpoint with strong authentication mechanisms.\\n\\n## Resources\\n\\n- [Go net/http/pprof Package Documentation](https://pkg.go.dev/net/http/pprof)\\n- [Go Build Constraints Documentation](https://pkg.go.dev/go/build#hdr-Build_Constraints)\\n- [OWASP Security by Design Principles](https://owasp.org/www-project-security-by-design/)\\n",
       "documentation_url": "https://docs.bearer.com/reference/rules/go_gosec_leak_pprof_endpoint",
-      "line_number": 3,
+      "line_number": 7,
       "full_filename": "/tmp/bearer-scan/main.go",
       "filename": ".",
       "source": {
-        "start": 3,
-        "end": 8,
+        "start": 7,
+        "end": 7,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 4,
+          "end": 20
         }
       },
       "sink": {
-        "start": 3,
-        "end": 8,
+        "start": 7,
+        "end": 7,
         "column": {
-          "start": 1,
-          "end": 2
+          "start": 4,
+          "end": 20
         },
-        "content": "import (\\n\\t\\"fmt\\"\\n\\t\\"log\\"\\n\\t\\"net/http\\"\\n\\t_ \\"net/http/pprof\\"\\n)"
+        "content": "\\"net/http/pprof\\""
       },
-      "parent_line_number": 3,
-      "snippet": "import (\\n\\t\\"fmt\\"\\n\\t\\"log\\"\\n\\t\\"net/http\\"\\n\\t_ \\"net/http/pprof\\"\\n)",
+      "parent_line_number": 7,
+      "snippet": "\\"net/http/pprof\\"",
       "fingerprint": "76d7f307921424da0f234602dea9aaa7_0",
       "old_fingerprint": "402bf06eb23c86740dd7ee778fce3c5f_0",
-      "code_extract": "import (\\n\\t\\"fmt\\"\\n\\t\\"log\\"\\n\\t\\"net/http\\"\\n\\t_ \\"net/http/pprof\\"\\n)"
+      "code_extract": "\\t_ \\"net/http/pprof\\""
     }
   ]
 }"


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Set the focus on the encryption library.
That way, the correct library is being reported and we don't end up reporting an entire `import` block and end up reporting omitted lines with the vuln being in one of those omitted lines

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
