### PR TITLE
docs: fix broken link in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ For example
 Here are the basic steps to adding a new rule.
 
 1. Create a rule YAML file following the guide [here](https://docs.bearer.com/guides/custom-rule/)
-2. Add a directory of test data. This includes example code that should (or for "ok" cases, should not) trigger your new rule. See [here](https://github.com/Bearer/bearer-rules/tests/ruby/lang/logger/testdata) for a simple Ruby example test.
+2. Add a directory of test data. This includes example code that should (or for "ok" cases, should not) trigger your new rule. See [here](/tests/ruby/lang/logger/testdata) for a simple Ruby example test.
 3. Scaffold tests by running
 ```bash
   node ./scripts/gen_tests.js


### PR DESCRIPTION
## Description

Use relative link - current link is a 404 because it is missing the tree

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
