### PR TITLE
feat: add script to write test files for V2 tests

### DIFF
--- a/scripts/write_v2_testfile.js
+++ b/scripts/write_v2_testfile.js
@@ -57,7 +57,7 @@ function writeTestFileIfNotExists(filePath) {
       testdataFileName = "main.rb";
     }
 
-    const testdataFilePath = path.join(filePath, testdataFileName);
+    const testdataFilePath = path.join(filePath, "testdata", testdataFileName);
 
     // write testdata file
     if (!fs.existsSync(testdataFilePath)) {

--- a/scripts/write_v2_testfile.js
+++ b/scripts/write_v2_testfile.js
@@ -1,0 +1,65 @@
+const fs = require("fs");
+const path = require("path");
+
+FILE_MAPPING = {
+  "go/": "test.go",
+  "java/": "test.java",
+  "javascript/": "test.js",
+  "php/": "test.php",
+  "python/": "test.py",
+  "ruby/": "test.rb",
+};
+
+function writeTestFileIfNotExists(filePath) {
+  try {
+    filePath = filePath.replace(".yml", "");
+    filePath = filePath.replace("/rules/", "/tests/");
+
+    var content =
+      "// Use bearer:expected <rule_name> to flag expected findings";
+    if (filePath.includes("python") || filePath.includes("ruby")) {
+      content = "# Use bearer:expected <rule_name> to flag expected findings";
+    }
+
+    var testFilename = "";
+    if (filePath.includes("go")) {
+      testFilename = "main.go";
+    }
+    if (filePath.includes("java")) {
+      testFilename = "main.java";
+    }
+    if (filePath.includes("javascript")) {
+      // ordering is important here
+      // javascript must come after java
+      testFilename = "app.js";
+    }
+    if (filePath.includes("php")) {
+      testFilename = "index.php";
+    }
+    if (filePath.includes("python")) {
+      testFilename = "main.py";
+    }
+    if (filePath.includes("ruby")) {
+      testFilename = "main.rb";
+    }
+
+    const fullFilePath = path.join(filePath, testFilename);
+
+    if (!fs.existsSync(fullFilePath)) {
+      const directoryPath = path.dirname(fullFilePath);
+
+      if (!fs.existsSync(directoryPath)) {
+        fs.mkdirSync(directoryPath, { recursive: true });
+      }
+
+      fs.writeFileSync(fullFilePath, content, "utf8");
+      console.error(`Test file ${fullFilePath} written successfully.`);
+    } else {
+      console.error(`Test file already exists ${fullFilePath}`);
+    }
+  } catch (err) {
+    console.error("Error writing test file:", err);
+  }
+}
+
+writeTestFileIfNotExists(process.argv[2]);


### PR DESCRIPTION
## Description

Add simple helper script to write a testdata and test.js files (and any folders, if not existing) for a new rule being added

Usage example

```bash

node scripts/write_v2_testfile.js "/Users/mish/Bearer/bearer-rules/rules/java/lang/logger.yml" 

```

will create the following testdata file: 

`/Users/mish/Bearer/bearer-rules/tests/java/lang/logger/main.java`

with the following content:

```
// Use bearer:expected <rule_name> to flag expected findings
```

and an associated test.js file with the following content: 

```
const {
  createNewInvoker,
  getEnvironment,
} = require("../../../helper.js")
const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)

describe(ruleId, () => {
  const invoke = createNewInvoker(ruleId, ruleFile, testBase)

  test("logger", () => {
    const testCase = "main.java"

    const results = invoke(testCase)

    expect(results.Missing).toEqual([])
    expect(results.Extra).toEqual([])
  })
})
```

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
