### PR TITLE
feat(java): add bad hex conversion rule

### DIFF
--- a/rules/java/lang/bad_hex_conversion.yml
+++ b/rules/java/lang/bad_hex_conversion.yml
@@ -1,0 +1,51 @@
+imports:
+  - java_shared_lang_message_digest_buffer
+patterns:
+  - pattern: |
+      Integer.toHexString($<MESSAGE_DIGEST_BUFFER_BYTE>)
+    filters:
+      - variable: MESSAGE_DIGEST_BUFFER_BYTE
+        detection: java_lang_bad_hex_conversion_digest_buffer_byte
+        scope: result
+auxiliary:
+  - id: java_lang_bad_hex_conversion_digest_buffer_byte
+    patterns:
+      - pattern: $<MESSAGE_DIGEST_BUFFER>[$<_>]
+        filters:
+          - variable: MESSAGE_DIGEST_BUFFER
+            detection: java_shared_lang_message_digest_buffer
+            scope: cursor
+languages:
+  - java
+severity: warning
+metadata:
+  description: "Bad hex conversion on digest array detected."
+  remediation_message: |
+    ## Description
+    The application currently utilizes Integer.toHexString on a digest array buffer, potentially resulting in inaccurate values.
+
+    ## Remediations
+    ❌ Avoid using Integer.toHexString for hexadecimal representation due to potential inaccuracies.
+
+    ✅ For Java 17 and above, leverage the java.util.HexFormat object for improved handling of hexadecimal representation
+
+    ```java
+    MessageDigest sha256Digest = MessageDigest.getInstance("SHA-256");
+    sha256Digest.update("hello world".getBytes(StandardCharsets.UTF_8));
+    byte[] output = sha256Digest.digest();
+
+    HexFormat hex = HexFormat.of();
+    String hexString = hex.formatHex(output);
+    ```
+
+    For older Java applications, consider using javax.xml.bind.DatatypeConverter as an alternative.
+
+    ## Resources
+
+    - [DatatypeConverter](https://docs.oracle.com/javase/9/docs/api/javax/xml/bind/DatatypeConverter.html#printHexBinary-byte:A-)
+
+  cwe_id:
+    - 704
+  id: java_lang_bad_hex_conversion
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_bad_hex_conversion
+  cloud_code_suggestions: true

--- a/rules/java/lang/bad_hex_conversion.yml
+++ b/rules/java/lang/bad_hex_conversion.yml
@@ -10,7 +10,7 @@ patterns:
 auxiliary:
   - id: java_lang_bad_hex_conversion_digest_buffer_byte
     patterns:
-      - pattern: $<MESSAGE_DIGEST_BUFFER>[$<_>]
+      - pattern: $<MESSAGE_DIGEST_BUFFER>;
         filters:
           - variable: MESSAGE_DIGEST_BUFFER
             detection: java_shared_lang_message_digest_buffer

--- a/rules/java/shared/lang/message_digest_any_init.yml
+++ b/rules/java/shared/lang/message_digest_any_init.yml
@@ -1,0 +1,13 @@
+type: shared
+languages:
+  - java
+imports:
+  - java_shared_lang_string
+patterns:
+  - pattern: $<JAVA_SHARED_LANG_MESSAGE_DIGEST_ANY_INIT_TYPE>.getInstance()
+    filters:
+      - variable: JAVA_SHARED_LANG_MESSAGE_DIGEST_ANY_INIT_TYPE
+        regex: \A(java\.security\.)?MessageDigest\z
+metadata:
+  description: "Java Message Digest any initializer"
+  id: java_shared_lang_message_digest_any_init

--- a/rules/java/shared/lang/message_digest_buffer.yml
+++ b/rules/java/shared/lang/message_digest_buffer.yml
@@ -1,0 +1,13 @@
+type: shared
+languages:
+  - java
+imports:
+  - java_shared_lang_message_digest_any_init
+patterns:
+  - pattern: $<JAVA_SHARED_LANG_MESSAGE_DIGEST_INIT>.digest($<...>)
+    filters:
+      - variable: JAVA_SHARED_LANG_MESSAGE_DIGEST_INIT
+        detection: java_shared_lang_message_digest_any_init
+metadata:
+  description: "Java Message Digest Buffer"
+  id: java_shared_lang_message_digest_buffer

--- a/tests/java/lang/bad_hex_conversion/test.js
+++ b/tests/java/lang/bad_hex_conversion/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("bad_hex_conversion", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/bad_hex_conversion/testdata/main.java
+++ b/tests/java/lang/bad_hex_conversion/testdata/main.java
@@ -1,0 +1,41 @@
+package strings;
+
+import java.security.MessageDigest;
+
+public class BadHexConversion {
+
+    public String bad(String text) {
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        byte[] resultBytes = md.digest(text.getBytes("UTF-8"));
+
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0, resultBytesLength = resultBytes.length; i < resultBytesLength; i++) {
+            byte b = resultBytes[i];
+            // bearer:expected java_lang_bad_hex_conversion
+            String badHex = Integer.toHexString(b);
+
+            // bearer:expected java_lang_bad_hex_conversion
+            stringBuilder.append(Integer.toHexString(resultBytes[i]));
+        }
+
+        for (byte b : resultBytes) {
+          // TODO: expected java_lang_bad_hex_conversion
+          stringBuilder.append(Integer.toHexString(b));
+        }
+        return stringBuilder.toString();
+    }
+
+    public static String ok(String password) {
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        byte[] resultBytes = md.digest(password.getBytes("UTF-8"));
+
+        HexFormat hex = HexFormat.of();
+        StringBuilder stringBuilder = new StringBuilder();
+        // ok not expected
+        for (byte b : resultBytes) {
+            stringBuilder.append(hex.formatHex(b));
+        }
+
+        return stringBuilder.toString();
+    }
+}

--- a/tests/java/lang/bad_hex_conversion/testdata/main.java
+++ b/tests/java/lang/bad_hex_conversion/testdata/main.java
@@ -19,8 +19,8 @@ public class BadHexConversion {
         }
 
         for (byte b : resultBytes) {
-          // TODO: expected java_lang_bad_hex_conversion
-          stringBuilder.append(Integer.toHexString(b));
+            // bearer:expected java_lang_bad_hex_conversion
+            stringBuilder.append(Integer.toHexString(b));
         }
         return stringBuilder.toString();
     }


### PR DESCRIPTION
## Description

Add Java lang rule for bad Hex conversions for digest buffers which can lead to inaccurate results. 

This rule has a default `warning` level severity

Relates to #197

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [x] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
