### PR TITLE
feat(jave): add CRLF injection rule

### DIFF
--- a/rules/java/lang/crlf_injection.yml
+++ b/rules/java/lang/crlf_injection.yml
@@ -1,0 +1,110 @@
+patterns:
+  - pattern: |
+      $<LOG>.$<METHOD>($<...>$<UNSANITIZED_USER_INPUT>$<...>)
+    filters:
+      - variable: UNSANITIZED_USER_INPUT
+        detection: java_lang_log_dynamic_input
+        scope: result
+      - not:
+          variable: UNSANITIZED_USER_INPUT
+          detection: java_lang_log_sanitized_dynamic_input
+          scope: result
+      - not:
+          variable: UNSANITIZED_USER_INPUT
+          detection: java_lang_log_dynamic_bundle_input
+          scope: result
+      - variable: METHOD
+        values:
+          - config
+          - debug
+          - entering
+          - error
+          - exiting
+          - fine
+          - finer
+          - finest
+          - info
+          - log
+          - logp
+          - logrb
+          - severe
+          - throwing
+          - trace
+          - warn
+      - variable: LOG
+        values:
+          - log
+          - logger
+auxiliary:
+  - id: java_lang_log_dynamic_bundle_input
+    patterns:
+      - pattern: $<_> + "bundle"
+  - id: java_lang_log_dynamic_input
+    patterns:
+      - pattern: $<REQUEST>.$<REQUEST_METHOD>()
+        filters:
+          - variable: REQUEST
+            values:
+              - req
+              - request
+          - variable: REQUEST_METHOD
+            values:
+              - getCookies
+              - getHeader
+              - getQueryString
+              - getRequestURI
+              - getRequestURL
+              - getAttribute
+              - getInputStream
+              - getParameter
+              - getParameterMap
+              - getParameterNames
+              - getParameterValues
+              - getReader
+              - getHeaderNames
+              - getPart
+              - getParts
+  - id: java_lang_log_sanitized_dynamic_input
+    patterns:
+      - pattern: $<_>.$<METHOD>($<SOURCE>, $<_>);
+        filters:
+          - variable: METHOD
+            values:
+              - replace
+              - replaceAll
+          - variable: SOURCE
+            string_regex: "\\r\\n|\\\\r\\\\n"
+      - pattern: $<_>.$<METHOD>($<CR>, $<_>).$<METHOD>($<LF>, $<_>);
+        filters:
+          - variable: METHOD
+            values:
+              - replace
+              - replaceAll
+          - variable: CR
+            string_regex: "\\r|\\\\r"
+          - variable: LF
+            string_regex: "\\n|\\\\n"
+languages:
+  - java
+metadata:
+  description: "Possible CLRF injection detected."
+  remediation_message: |
+    ## Description
+
+    A CRLF (Carriage Return Line Feed) injection occurs when an attacker injects a sequence of line termination characters into a log message, allowing them to forge log entries.
+
+    ## Remediations
+
+    ✅ Strip any carriage return and line feed characters from user input data before logging it.
+
+    ```java
+    logger.info(userInput.replaceAll("[\r\n]+", ""));
+    ```
+
+    ## Resources
+    - [OWASP CRLF Injection] (https://owasp.org/www-community/vulnerabilities/CRLF_Injection)
+    - [OWASP logging cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)
+  cwe_id:
+    - 93
+  id: java_lang_crlf_injection
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_crlf_injection

--- a/rules/java/lang/crlf_injection.yml
+++ b/rules/java/lang/crlf_injection.yml
@@ -1,9 +1,18 @@
+imports:
+  - java_shared_lang_user_input
+  - java_shared_lang_logger_methods
 patterns:
   - pattern: |
       $<LOG>.$<METHOD>($<...>$<UNSANITIZED_USER_INPUT>$<...>)
     filters:
+      - variable: LOG
+        values:
+          - log
+          - logger
+      - variable: METHOD
+        detection: java_shared_lang_logger_methods
       - variable: UNSANITIZED_USER_INPUT
-        detection: java_lang_log_dynamic_input
+        detection: java_shared_lang_user_input
         scope: result
       - not:
           variable: UNSANITIZED_USER_INPUT
@@ -13,57 +22,10 @@ patterns:
           variable: UNSANITIZED_USER_INPUT
           detection: java_lang_log_dynamic_bundle_input
           scope: result
-      - variable: METHOD
-        values:
-          - config
-          - debug
-          - entering
-          - error
-          - exiting
-          - fine
-          - finer
-          - finest
-          - info
-          - log
-          - logp
-          - logrb
-          - severe
-          - throwing
-          - trace
-          - warn
-      - variable: LOG
-        values:
-          - log
-          - logger
 auxiliary:
   - id: java_lang_log_dynamic_bundle_input
     patterns:
       - pattern: $<_> + "bundle"
-  - id: java_lang_log_dynamic_input
-    patterns:
-      - pattern: $<REQUEST>.$<REQUEST_METHOD>()
-        filters:
-          - variable: REQUEST
-            values:
-              - req
-              - request
-          - variable: REQUEST_METHOD
-            values:
-              - getCookies
-              - getHeader
-              - getQueryString
-              - getRequestURI
-              - getRequestURL
-              - getAttribute
-              - getInputStream
-              - getParameter
-              - getParameterMap
-              - getParameterNames
-              - getParameterValues
-              - getReader
-              - getHeaderNames
-              - getPart
-              - getParts
   - id: java_lang_log_sanitized_dynamic_input
     patterns:
       - pattern: $<_>.$<METHOD>($<SOURCE>, $<_>);

--- a/rules/java/lang/crlf_injection.yml
+++ b/rules/java/lang/crlf_injection.yml
@@ -11,6 +11,10 @@ patterns:
           - logger
       - variable: METHOD
         detection: java_shared_lang_logger_methods
+      - not:
+          variable: METHOD
+          values:
+            - logrb
       - variable: UNSANITIZED_USER_INPUT
         detection: java_shared_lang_user_input
         scope: result
@@ -18,14 +22,35 @@ patterns:
           variable: UNSANITIZED_USER_INPUT
           detection: java_lang_log_sanitized_dynamic_input
           scope: result
+  - pattern: |
+      $<LOG>.logrb($<_>, $<_>, $<UNSANITIZED_USER_INPUT>$<...>)
+    filters:
+      - variable: LOG
+        values:
+          - log
+          - logger
+      - variable: UNSANITIZED_USER_INPUT
+        detection: java_shared_lang_user_input
+        scope: result
       - not:
           variable: UNSANITIZED_USER_INPUT
-          detection: java_lang_log_dynamic_bundle_input
+          detection: java_lang_log_sanitized_dynamic_input
+          scope: result
+  - pattern: |
+      $<LOG>.logrb($<_>, $<_>, $<_>, $<_>, $<UNSANITIZED_USER_INPUT>$<...>)
+    filters:
+      - variable: LOG
+        values:
+          - log
+          - logger
+      - variable: UNSANITIZED_USER_INPUT
+        detection: java_shared_lang_user_input
+        scope: result
+      - not:
+          variable: UNSANITIZED_USER_INPUT
+          detection: java_lang_log_sanitized_dynamic_input
           scope: result
 auxiliary:
-  - id: java_lang_log_dynamic_bundle_input
-    patterns:
-      - pattern: $<_> + "bundle"
   - id: java_lang_log_sanitized_dynamic_input
     patterns:
       - pattern: $<_>.$<METHOD>($<SOURCE>, $<_>);

--- a/rules/java/lang/log_injection.yml
+++ b/rules/java/lang/log_injection.yml
@@ -7,12 +7,22 @@ patterns:
         scope: result
       - variable: METHOD
         values:
-          - log
+          - config
           - debug
-          - warn
-          - info
+          - entering
           - error
+          - exiting
+          - fine
+          - finer
+          - finest
+          - info
+          - log
+          - logp
+          - logrb
+          - severe
+          - throwing
           - trace
+          - warn
       - variable: LOG
         values:
           - log

--- a/rules/java/lang/log_injection.yml
+++ b/rules/java/lang/log_injection.yml
@@ -1,59 +1,19 @@
+imports:
+  - java_shared_lang_user_input
+  - java_shared_lang_logger_methods
 patterns:
   - pattern: |
       $<LOG>.$<METHOD>($<...>$<USER_INPUT>$<...>)
     filters:
       - variable: USER_INPUT
-        detection: java_lang_log_dynamic_input
+        detection: java_shared_lang_user_input
         scope: result
       - variable: METHOD
-        values:
-          - config
-          - debug
-          - entering
-          - error
-          - exiting
-          - fine
-          - finer
-          - finest
-          - info
-          - log
-          - logp
-          - logrb
-          - severe
-          - throwing
-          - trace
-          - warn
+        detection: java_shared_lang_logger_methods
       - variable: LOG
         values:
           - log
           - logger
-auxiliary:
-  - id: java_lang_log_dynamic_input
-    patterns:
-      - pattern: |
-          $<REQUEST>.$<REQUEST_METHOD>()
-        filters:
-          - variable: REQUEST
-            values:
-              - req
-              - request
-          - variable: REQUEST_METHOD
-            values:
-              - getCookies
-              - getHeader
-              - getQueryString
-              - getRequestURI
-              - getRequestURL
-              - getAttribute
-              - getInputStream
-              - getParameter
-              - getParameterMap
-              - getParameterNames
-              - getParameterValues
-              - getReader
-              - getHeaderNames
-              - getPart
-              - getParts
 languages:
   - java
 

--- a/rules/java/lang/logger.yml
+++ b/rules/java/lang/logger.yml
@@ -1,5 +1,6 @@
 imports:
   - java_shared_lang_datatype
+  - java_shared_lang_logger_methods
 patterns:
   - pattern: |
       $<LOG>.$<METHOD>($<...>$<DATA_TYPE>$<...>)
@@ -8,12 +9,7 @@ patterns:
         detection: java_shared_lang_datatype
         scope: result
       - variable: METHOD
-        values:
-          - log
-          - debug
-          - warn
-          - info
-          - error
+        detection: java_shared_lang_logger_methods
       - variable: LOG
         values:
           - log

--- a/rules/java/shared/lang/logger_methods.yml
+++ b/rules/java/shared/lang/logger_methods.yml
@@ -1,0 +1,27 @@
+type: shared
+languages:
+  - java
+patterns:
+  - pattern: $<METHOD>;
+    filters:
+      - variable: METHOD
+        values:
+          - config
+          - debug
+          - entering
+          - error
+          - exiting
+          - fine
+          - finer
+          - finest
+          - info
+          - log
+          - logp
+          - logrb
+          - severe
+          - throwing
+          - trace
+          - warn
+metadata:
+  description: "Java Logger Methods"
+  id: java_shared_lang_logger_methods

--- a/tests/java/lang/crlf_injection/test.js
+++ b/tests/java/lang/crlf_injection/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("crlf_injection", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/crlf_injection/testdata/main.java
+++ b/tests/java/lang/crlf_injection/testdata/main.java
@@ -20,6 +20,15 @@ public class CRLFInjection extends HttpServlet {
     // bearer:expected java_lang_crlf_injection
     logger.info(dangerous.replaceAll("\r", ""));
 
+    // logrb cases
+    // - logrb​(Level level, ResourceBundle bundle, String msg, Object... params)
+    // - logrb​(Level level, String sourceClass, String sourceMethod, ResourceBundle bundle, String msg, Object... params)
+
+    // bearer:expected java_lang_crlf_injection
+    logger.logrb(Level.INFO, safe, dangerous, safe, safe);
+    // bearer:expected java_lang_crlf_injection
+    logger.logrb(Level.INFO, safe, safe, ResourceBundle.getBundle("package.ExampleResource", locale), dangerous, safe);
+
     // okay
     logger.config("hello world" + okay);
     logger.info(dangerous.replace('\r', ' ').replace('\n', ' '));

--- a/tests/java/lang/crlf_injection/testdata/main.java
+++ b/tests/java/lang/crlf_injection/testdata/main.java
@@ -1,0 +1,29 @@
+package inject;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.logging.*;
+
+public class CRLFInjection extends HttpServlet {
+  public void javaUtilLogging(HttpServletRequest req, HttpServletResponse res) {
+    String dangerous = req.getParameter("test");
+    String okay = "some known string";
+
+    logger = Logger.getLogger(Log.class);
+    logger.setLevel(Level.ALL);
+
+    // bearer:expected java_lang_crlf_injection
+    logger.info(dangerous);
+    // bearer:expected java_lang_crlf_injection
+    logger.info(dangerous.replace("hello", "world"));
+    // bearer:expected java_lang_crlf_injection
+    logger.info(dangerous.replace('\n', ""));
+    // bearer:expected java_lang_crlf_injection
+    logger.info(dangerous.replaceAll("\r", ""));
+
+    // okay
+    logger.config("hello world" + okay);
+    logger.info(dangerous.replace('\r', ' ').replace('\n', ' '));
+    logger.logrb(Level.INFO, safe, safe, dangerous + "bundle", safe);
+    logger.fine(dangerous.replaceAll("[\r\n]+", ""));
+  }
+}

--- a/tests/java/lang/log_injection/test.js
+++ b/tests/java/lang/log_injection/test.js
@@ -1,13 +1,24 @@
-const { createInvoker, getEnvironment } = require("../../../helper.js")
+const { createInvoker, createNewInvoker, getEnvironment } = require("../../../helper.js")
 const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
 
 describe(ruleId, () => {
   const invoke = createInvoker(ruleId, ruleFile, testBase)
-  
 
   test("log_injection", () => {
     const testCase = "log_injection.java"
     expect(invoke(testCase)).toMatchSnapshot();
   })
-  
+
+  // new style tests
+  const invokeV2 = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("log_injection_v2", () => {
+    const testCase = "main.java"
+
+    const results = invokeV2(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+
 })

--- a/tests/java/lang/log_injection/testdata/main.java
+++ b/tests/java/lang/log_injection/testdata/main.java
@@ -1,0 +1,22 @@
+package inject;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.logging.*;
+
+public class Log extends HttpServlet {
+    public void javaUtilLogging(HttpServletRequest req, HttpServletResponse res) {
+        String dangerous = req.getParameter("test");
+
+        logger = Logger.getLogger(Log.class);
+        logger.setLevel(Level.ALL);
+
+        // bearer:expected java_lang_log_injection
+        logger.config(dangerous);
+        // bearer:expected java_lang_log_injection
+        logger.exiting("Exit:" + dangerous);
+
+        // okay
+        logger.fine("hello world");
+    }
+
+}


### PR DESCRIPTION
## Description

Add Java rule for Carriage Return, Line Feed injection attacks
Some refactoring of other logger rules, to remove shared functionality

Relates to #197

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
