### PR TITLE
feat(java): custom MessageDigest class

### DIFF
--- a/rules/java/lang/custom_message_digest_class.yml
+++ b/rules/java/lang/custom_message_digest_class.yml
@@ -1,6 +1,6 @@
 patterns:
   - pattern: |
-      class $<_> extends $<MESSAGE_DIGEST_CLASS> {};
+      class $<...>$<_> extends $<MESSAGE_DIGEST_CLASS> {};
     filters:
       - variable: MESSAGE_DIGEST_CLASS
         regex: \A(java\.security\.)?MessageDigest\z

--- a/rules/java/lang/custom_message_digest_class.yml
+++ b/rules/java/lang/custom_message_digest_class.yml
@@ -1,0 +1,29 @@
+patterns:
+  - pattern: |
+      class $<_> extends $<MESSAGE_DIGEST_CLASS> {};
+    filters:
+      - variable: MESSAGE_DIGEST_CLASS
+        regex: \A(java\.security\.)?MessageDigest\z
+languages:
+  - java
+severity: warning
+metadata:
+  description: "Custom implementation of a Digest class detected."
+  remediation_message: |
+    ## Description
+
+    Implementing a custom Digest class manually is not advised as the process could lead to errors.
+    Instead use a standard Digest algorithm such as SHA-256 or SHA-512.
+
+    ## Remediations
+
+    ❌ Do not implement a custom Digest class by hand
+
+    ✅ Choose a standard Digest algorithm as SHA-256, SHA-384, SHA-512, or SHA-512/256.
+
+    ## Resources
+    - [Java MessageDigest class](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/security/MessageDigest.html)
+  cwe_id:
+    - 327
+  id: java_lang_custom_message_digest_class
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_custom_message_digest_class

--- a/tests/java/lang/custom_message_digest_class/test.js
+++ b/tests/java/lang/custom_message_digest_class/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("custom_message_digest_class", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/custom_message_digest_class/testdata/main.java
+++ b/tests/java/lang/custom_message_digest_class/testdata/main.java
@@ -1,0 +1,13 @@
+package crypto;
+
+import java.security.MessageDigest;
+
+// bearer:expected java_lang_custom_message_digest_class
+public class CustomMessageDigest extends MessageDigest {
+  // some custom implementation process
+}
+
+// bearer:expected java_lang_custom_message_digest_class
+class MyOtherCustomMessageDigest extends java.security.MessageDigest {
+  // some custom implementation process
+}


### PR DESCRIPTION
## Description

Add warning-level rule against implementing custom `MessageDigest` classes

Relates to #197

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
