### PR TITLE
feat(java): add SQL external config rule

### DIFF
--- a/rules/java/lang/external_config_control.yml
+++ b/rules/java/lang/external_config_control.yml
@@ -1,0 +1,39 @@
+imports:
+  - java_shared_lang_instance
+  - java_shared_lang_user_input
+patterns:
+  - pattern: |
+      $<SQL_CONN>.setCatalog($<USER_INPUT>);
+    filters:
+      - variable: SQL_CONN
+        detection: java_shared_lang_instance
+        scope: cursor
+        filters:
+          - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+            regex: \A(java\.sql\.)?Connection\z
+      - variable: USER_INPUT
+        detection: java_shared_lang_user_input
+        scope: cursor
+languages:
+  - java
+severity: warning
+metadata:
+  description: "User input in SQL Connection setCatalog detected."
+  remediation_message: |
+    ## Description
+
+    It is bad security practice to use unsanitized user input when configuring a SQL Connection's catalog.
+    This could allow an attacker to provide their own catalog name to the setCatalog method call, resulting in unexpected or malicious application behaviour.
+
+    ## Remediations
+
+    ❌ Avoid Direct User Input
+
+    Do not use user-supplied information when setting the catalog for your SQL database
+
+    ## Resources
+    - [Java SQL Connection](https://docs.oracle.com/en/java/javase/21/docs/api/java.sql/java/sql/Connection.html)
+  cwe_id:
+    - 15
+  id: java_lang_external_config_control
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_external_config_control

--- a/tests/java/lang/external_config_control/test.js
+++ b/tests/java/lang/external_config_control/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("external_config_control", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/external_config_control/testdata/main.java
+++ b/tests/java/lang/external_config_control/testdata/main.java
@@ -1,0 +1,29 @@
+// Use bearer:expected java_lang_external_config_control to flag expected findings
+package unsafe;
+
+import javax.servlet.http.HttpServletRequest;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class Connect {
+  private HttpServletRequest globalRequest;
+  private Connection globalConn;
+
+  public static void bad(Connection conn, HttpServletRequest request) throws SQLException {
+    var foo = request.getParameter("foo");
+    // bearer:expected java_lang_external_config_control
+    conn.setCatalog(foo);
+  }
+
+  public void bad2() throws SQLException {
+    String bar = globalRequest.getParameter("bar");
+    // bearer:expected java_lang_external_config_control
+    globalConn.setCatalog(bar);
+  }
+
+  public static void ok(Connection conn, HttpServletRequest request) throws SQLException {
+    var baz = org.apache.commons.text.StringEscapeUtils.unescapeJava(request.getParameter("baz"));
+    conn.setCatalog(baz);
+    globalConn.setCatalog("known");
+  }
+}


### PR DESCRIPTION
## Description

Add external config CWE-15 rule for Java to catch SQL Connection setCatalog method calls with user supplied input

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
