### PR TITLE
feat(java): add file upload filename rule

### DIFF
--- a/rules/java/lang/file_upload_filename.yml
+++ b/rules/java/lang/file_upload_filename.yml
@@ -1,0 +1,70 @@
+imports:
+  - java_shared_lang_instance
+sanitizer: java_lang_file_upload_filename_sanitized_name
+patterns:
+  - pattern: |
+      $<UPLOADED_FILE>.getName()
+    filters:
+      - variable: UPLOADED_FILE
+        detection: java_lang_file_upload_filename_uploaded_servlet_file
+        scope: result
+auxiliary:
+  - id: java_lang_file_upload_filename_sanitized_name
+    patterns:
+      - pattern: FilenameUtils.getName($<!>$<_>)
+  - id: java_lang_file_upload_filename_uploaded_servlet_file
+    patterns:
+      - pattern: |
+          for (FileItem $<FILE_ITEM> : $<UPLOADED_FILES>) {}
+        focus: FILE_ITEM
+        filters:
+          - variable: UPLOADED_FILES
+            detection: java_lang_file_upload_filename_uploaded_servlet_files
+  - id: java_lang_file_upload_filename_uploaded_servlet_files
+    patterns:
+      - pattern: $<SERVLET>.parseRequest($<SERVLET_REQ>);
+        filters:
+          - variable: SERVLET
+            detection: java_shared_lang_instance
+            scope: cursor
+            filters:
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(org\.apache\.commons\.fileupload\.servlet)?ServletFileUpload\z
+          - variable: SERVLET_REQ
+            detection: java_shared_lang_instance
+            scope: cursor
+            filters:
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(java\.servlet\.http\.)?HttpServletRequest\z
+languages:
+  - java
+metadata:
+  description: Unsanitized use of FileUpload filename detected
+  remediation_message: |
+    ## Description
+
+    The unsanitized use of the filename provided by FileUpload could lead to path traversal attacks, since an attacker could manipulate the filename to gain access to unauthorized resources.
+    Try to avoid referencing filenames that are open to such manipulation, or if it is unavoidable, ensure that the filename is sanitized and that appropriate validation measures are taken.
+
+    ## Remediations
+
+    ❌ Avoid wherever possible
+
+    ✅ Sanitize user input when resolving paths, for example by using `FilenameUtils.getName()` to normalize the path:
+
+    ```java
+      ServletFileUpload upload = new ServletFileUpload();
+      List<FileItem> fileItems = upload.parseRequest(request);
+
+      for (FileItem item : fileItems) {
+        String filename = FilenameUtils.getName(item.getName());
+        // ...
+      }
+    ```
+
+    ## Resources
+    - [OWASP path traversal](https://owasp.org/www-community/attacks/Path_Traversal)
+  cwe_id:
+    - 22
+  id: java_lang_file_upload_filename
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_file_upload_filename

--- a/tests/java/lang/file_upload_filename/test.js
+++ b/tests/java/lang/file_upload_filename/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("file_upload_filename", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/file_upload_filename/testdata/main.java
+++ b/tests/java/lang/file_upload_filename/testdata/main.java
@@ -1,0 +1,22 @@
+package file;
+
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.FileUploadException;
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+public class foo {
+    public void bad(HttpServletRequest request) throws FileUploadException {
+        ServletFileUpload upload = new ServletFileUpload();
+        List<FileItem> fileItems = upload.parseRequest(request);
+
+        for (FileItem item : fileItems) {
+          // bearer:expected java_lang_file_upload_filename
+          String badFileName = item.getName();
+          // ok - sanitized
+          String okFileName = FilenameUtils.getName(item.getName());
+          //...
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add rule for path traversal with Java FileUpload filename

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
