### PR TITLE
feat(java): empty database password rule

### DIFF
--- a/rules/java/lang/empty_database_password.yml
+++ b/rules/java/lang/empty_database_password.yml
@@ -1,0 +1,32 @@
+patterns:
+  - pattern: |
+      $<SQL_DRIVER_MANAGER>.getConnection($<_>, $<_>, $<EMPTY_STRING>)
+    filters:
+      - variable: SQL_DRIVER_MANAGER
+        regex: \A(java\.sql\.)?DriverManager\z
+      - variable: EMPTY_STRING
+        string_regex: \A\z
+
+languages:
+  - java
+severity: warning
+metadata:
+  description: "Empty database password detected."
+  remediation_message: |
+    ## Description
+
+    A database with an empty password is a security risk as its data is unprotected.
+    Database servers should be configured with appropriate authentication and restrictions, and their passwords should be stored and accessed securely - for example, through a Key Management Service (KMS).
+
+    ## Remediations
+
+    ❌ Do not configure database servers with empty passwords
+
+    ✅ Always ensure secure password management practices
+
+    ## Resources
+    - [OWASP hardcoded passwords](https://owasp.org/www-community/vulnerabilities/Use_of_hard-coded_password)
+  cwe_id:
+    - 306
+  id: java_lang_empty_database_password
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_empty_database_password

--- a/tests/java/lang/empty_database_password/test.js
+++ b/tests/java/lang/empty_database_password/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("empty_database_password", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/empty_database_password/testdata/main.java
+++ b/tests/java/lang/empty_database_password/testdata/main.java
@@ -1,0 +1,17 @@
+// Use bearer:expected java_lang_empty_database_password to flag expected findings
+import java.sql.Connection;
+import java.sql.DriverManager;
+
+public class Foo
+{
+  public static void bad() {
+    String url = "jdbc:mysql://localhost:3306/foo";
+    // bearer:expected java_lang_empty_database_password
+    Connection conn = DriverManager.getConnection(url, "root", "");
+  }
+
+  public static void ok() {
+    String url = "jdbc:mysql://localhost:3306/bar";
+    Connection conn = DriverManager.getConnection(url, "admin", "admin");
+  }
+}


### PR DESCRIPTION
## Description

Add Java rule to catch databases configured with empty passwords

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
