### PR TITLE
feat(java): extend insecure cookie rules

### DIFF
--- a/rules/java/lang/cookie_missing_http_only.yml
+++ b/rules/java/lang/cookie_missing_http_only.yml
@@ -8,7 +8,7 @@ patterns:
         scope: cursor
         filters:
           - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
-            regex: \A(javax\.servlet\.http\.)?Cookie\z
+            regex: \A((javax|jakarta)\.servlet\.http\.)?Cookie\z
       - variable: "TRUE"
         detection: java_lang_cookie_missing_http_only_true
         scope: cursor
@@ -21,7 +21,7 @@ auxiliary:
       - pattern: new $<COOKIE_TYPE>();
         filters:
           - variable: COOKIE_TYPE
-            regex: \A(javax\.servlet\.http\.)?Cookie\z
+            regex: \A((javax|jakarta)\.servlet\.http\.)?Cookie\z
   - id: java_lang_cookie_missing_http_only_true
     patterns:
       - "true;"

--- a/rules/java/lang/cookie_missing_secure.yml
+++ b/rules/java/lang/cookie_missing_secure.yml
@@ -8,7 +8,7 @@ patterns:
         scope: cursor
         filters:
           - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
-            regex: \A(javax\.servlet\.http\.)?Cookie\z
+            regex: \A((javax|jakarta)\.servlet\.http\.)?Cookie\z
       - variable: "TRUE"
         detection: java_lang_cookie_missing_secure_true
         scope: cursor
@@ -21,7 +21,7 @@ auxiliary:
       - pattern: new $<COOKIE_TYPE>();
         filters:
           - variable: COOKIE_TYPE
-            regex: \A(javax\.servlet\.http\.)?Cookie\z
+            regex: \A((javax|jakarta)\.servlet\.http\.)?Cookie\z
   - id: java_lang_cookie_missing_secure_true
     patterns:
       - "true;"

--- a/tests/java/lang/cookie_missing_http_only/test.js
+++ b/tests/java/lang/cookie_missing_http_only/test.js
@@ -1,19 +1,29 @@
-const { createInvoker, getEnvironment } = require("../../../helper.js")
+const { createInvoker, createNewInvoker, getEnvironment } = require("../../../helper.js")
 const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
 
 describe(ruleId, () => {
-  const invoke = createInvoker(ruleId, ruleFile, testBase)
-  
+  const invoke = createInvoker(ruleId, ruleFile, testBase);
 
   test("bad", () => {
     const testCase = "bad.java"
     expect(invoke(testCase)).toMatchSnapshot();
   })
-  
+
 
   test("ok", () => {
     const testCase = "ok.java"
     expect(invoke(testCase)).toMatchSnapshot();
   })
-  
+
+  // new invoker
+  const invokeV2 = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("missing_http_only", () => {
+    const testCase = "main.java"
+
+    const results = invokeV2(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
 })

--- a/tests/java/lang/cookie_missing_http_only/testdata/main.java
+++ b/tests/java/lang/cookie_missing_http_only/testdata/main.java
@@ -1,0 +1,38 @@
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.Cookie;
+
+public class Test
+{
+  public static final String COOKIE_NAME = "someCookie";
+
+  public void badCookie(HttpServletResponse response) {
+    // bearer:expected java_lang_cookie_missing_http_only
+    Cookie cookie = new Cookie(COOKIE_NAME, "cookieValue");
+    cookie.setPath("/WebGoat");
+    response.addCookie(cookie);
+  }
+
+   public void badCookie2(HttpServletResponse res) {
+    // bearer:expected java_lang_cookie_missing_http_only
+    javax.servlet.http.Cookie cookie = new javax.servlet.http.Cookie(COOKIE_NAME, "cookieValue");
+    cookie.setSecure(true);
+    cookie.setMaxAge(60);
+    cookie.setHttpOnly(false);
+    res.addCookie(cookie);
+  }
+
+  public void badCookie3(HttpServletResponse res) {
+    // bearer:expected java_lang_cookie_missing_http_only
+    javax.servlet.http.Cookie cookie = new javax.servlet.http.Cookie(COOKIE_NAME, "cookieValue");
+    cookie.setSecure(true);
+    cookie.setMaxAge(60);
+    res.addCookie(cookie);
+  }
+
+  public void badJakartaCookie(HttpServletResponse response) {
+    // bearer:expected java_lang_cookie_missing_http_only
+    jakarta.servlet.http.Cookie jakartaCookie = new jakarta.servlet.http.Cookie(COOKIE_NAME, "someCookieValue");
+    jakartaCookie.setMaxAge(60);
+    response.addCookie(jakartaCookie);
+  }
+}

--- a/tests/java/lang/cookie_missing_secure/test.js
+++ b/tests/java/lang/cookie_missing_secure/test.js
@@ -1,19 +1,30 @@
-const { createInvoker, getEnvironment } = require("../../../helper.js")
+const { createInvoker, createNewInvoker, getEnvironment } = require("../../../helper.js")
 const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
 
 describe(ruleId, () => {
   const invoke = createInvoker(ruleId, ruleFile, testBase)
-  
+
 
   test("bad", () => {
     const testCase = "bad.java"
     expect(invoke(testCase)).toMatchSnapshot();
   })
-  
+
 
   test("ok", () => {
     const testCase = "ok.java"
     expect(invoke(testCase)).toMatchSnapshot();
   })
-  
+
+  // new invoker
+  const invokeV2 = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("missing_http_only", () => {
+    const testCase = "main.java"
+
+    const results = invokeV2(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
 })

--- a/tests/java/lang/cookie_missing_secure/testdata/main.java
+++ b/tests/java/lang/cookie_missing_secure/testdata/main.java
@@ -1,3 +1,5 @@
+// Use bearer:expected java_lang_cookie_missing_secure to flag expected findings
+
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Cookie;
 
@@ -6,26 +8,35 @@ public class Test
   public static final String COOKIE_NAME = "someCookie";
 
    public void badCookie(HttpServletResponse res) {
-    // bearer:expected java_lang_cookie_missing_http_only
+    // bearer:expected java_lang_cookie_missing_secure
     javax.servlet.http.Cookie cookie = new javax.servlet.http.Cookie(COOKIE_NAME, "cookieValue");
-    cookie.setSecure(true);
+    cookie.setSecure(false);
     cookie.setMaxAge(60);
-    cookie.setHttpOnly(false);
+    cookie.setHttpOnly(true);
     res.addCookie(cookie);
   }
 
   public void badCookie2(HttpServletResponse res) {
-    // bearer:expected java_lang_cookie_missing_http_only
+    // bearer:expected java_lang_cookie_missing_secure
     javax.servlet.http.Cookie cookie = new javax.servlet.http.Cookie(COOKIE_NAME, "cookieValue");
-    cookie.setSecure(true);
+    cookie.setHttpOnly(true);
     cookie.setMaxAge(60);
     res.addCookie(cookie);
   }
 
   public void badJakartaCookie(HttpServletResponse response) {
-    // bearer:expected java_lang_cookie_missing_http_only
+    // bearer:expected java_lang_cookie_missing_secure
     jakarta.servlet.http.Cookie jakartaCookie = new jakarta.servlet.http.Cookie(COOKIE_NAME, "someCookieValue");
     jakartaCookie.setMaxAge(60);
     response.addCookie(jakartaCookie);
   }
+
+  public void badJakartaCookie2(HttpServletResponse response) {
+    // bearer:expected java_lang_cookie_missing_secure
+    jakarta.servlet.http.Cookie jakartaCookie = new jakarta.servlet.http.Cookie(COOKIE_NAME, "someCookieValue");
+    jakartaCookie.setSecure(false);
+    jakartaCookie.setMaxAge(60);
+    response.addCookie(jakartaCookie);
+  }
 }
+


### PR DESCRIPTION
## Description

Add Jakarta case to Java insecure cookie rules

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
