### PR TITLE
feat(java): add missing SMTP SSL host check rule

### DIFF
--- a/rules/java/lang/missing_smtp_ssl_host_check.yml
+++ b/rules/java/lang/missing_smtp_ssl_host_check.yml
@@ -1,0 +1,59 @@
+imports:
+  - java_shared_lang_instance
+patterns:
+  - pattern: $<EMAIL_CLIENT>.setSSLCheckServerIdentity($<TRUE>);
+    filters:
+      - variable: EMAIL_CLIENT
+        detection: java_shared_lang_instance
+        scope: cursor
+        filters:
+          - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+            regex: \A(org\.apache\.commons\.mail\.)?(SimpleEmail|Email|MultiPartEmail|HtmlEmail|ImageHtmlEmail)\z
+      - variable: "TRUE"
+        detection: java_lang_missing_smtp_ssl_host_check_true
+        scope: cursor
+trigger:
+  match_on: absence
+  required_detection: java_lang_missing_smtp_ssl_host_check_set_ssl
+auxiliary:
+  - id: java_lang_missing_smtp_ssl_host_check_set_ssl
+    patterns:
+      - pattern: $<EMAIL_CLIENT2>.setSSLOnConnect($<TRUE>);
+        filters:
+          - variable: EMAIL_CLIENT2
+            detection: java_shared_lang_instance
+            scope: cursor
+            filters:
+              - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+                regex: \A(org\.apache\.commons\.mail\.)?(SimpleEmail|Email|MultiPartEmail|HtmlEmail|ImageHtmlEmail)\z
+          - variable: "TRUE"
+            detection: java_lang_missing_smtp_ssl_host_check_true
+            scope: cursor
+  - id: java_lang_missing_smtp_ssl_host_check_true
+    patterns:
+      - "true;"
+languages:
+  - java
+metadata:
+  description: "Missing SSL host check in SMTP."
+  remediation_message: |
+    ## Description
+
+    SSL certificates must be validated to check that the certificate is from the expected host and the server identity is correct.
+    Without such checks in place, the application is at risk of redirection or spoofing attacks, where an attacker impersonates a trusted host by using a valid SSL certificate from a different host.
+
+    ## Remediation
+
+    ✅ Always configure email client to check server identity
+
+    ```java
+      Email email = new Email();
+
+      email.setSSLOnConnect(true);
+      email.setSSLCheckServerIdentity(true);
+    ```
+  cwe_id:
+    - 297
+  id: java_lang_missing_smtp_ssl_host_check
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_missing_smtp_ssl_host_check
+  cloud_code_suggestions: true

--- a/tests/java/lang/missing_smtp_ssl_host_check/test.js
+++ b/tests/java/lang/missing_smtp_ssl_host_check/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("java_lang_missing_smtp_ssl_host_check", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/missing_smtp_ssl_host_check/testdata/main.java
+++ b/tests/java/lang/missing_smtp_ssl_host_check/testdata/main.java
@@ -1,0 +1,39 @@
+// Use bearer:expected java_lang_insecure_smtp to flag expected findings
+package smtp;
+
+import org.apache.commons.mail.Email;
+import org.apache.commons.mail.SimpleEmail;
+import org.apache.commons.mail.MultiPartEmail;
+import org.apache.commons.mail.HtmlEmail;
+import org.apache.commons.mail.ImageHtmlEmail;
+
+public class InsecureSmtp{
+
+    public static void main(String[] args) throws Exception {
+        Email email = new Email();
+        email.setHostName("smtp2.googlemail.com");
+        // bearer:expected java_lang_missing_smtp_ssl_host_check
+        email.setSSLOnConnect(true);
+        email.setSSLCheckServerIdentity(false);
+
+        Email simpleEmail = new SimpleEmail();
+        simpleEmail.setHostName("smtp2.googlemail.com");
+        // bearer:expected java_lang_missing_smtp_ssl_host_check
+        simpleEmail.setSSLOnConnect(true);
+
+        MultiPartEmail emailMulti = new MultiPartEmail();
+        // bearer:expected java_lang_missing_smtp_ssl_host_check
+        emailMulti.setSSLOnConnect(true);
+        emailMulti.setHostName("mail.myserver.com");
+
+        HtmlEmail htmlEmail = new HtmlEmail();
+        // bearer:expected java_lang_missing_smtp_ssl_host_check
+        htmlEmail.setSSLOnConnect(true);
+        htmlEmail.setHostName("mail.myserver.com");
+
+        // bad but not this rule
+        ImageHtmlEmail imageEmail = new ImageHtmlEmail();
+        imageEmail.setHostName("mail.myserver.com");
+        imageEmail.setSSLOnConnect(false);
+    }
+}


### PR DESCRIPTION
## Description

Add Java rule to check for missing SSL server identity check for SSL SMTP connections. 

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
