### PR TITLE
fix: multiple CWEs for Java EL injection rule

### DIFF
--- a/rules/java/lang/expression_language_injection.yml
+++ b/rules/java/lang/expression_language_injection.yml
@@ -50,6 +50,5 @@ metadata:
     - [OWASP Expression Language Injection](https://owasp.org/www-community/vulnerabilities/Expression_Language_Injection)
   cwe_id:
     - 917
-    - 94
   id: java_lang_expression_language_injection
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_expression_language_injection


### PR DESCRIPTION
## Description

Remove additional CWE for Java EL injection rule, leaving the correct CWE-917 Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')

https://cwe.mitre.org/data/definitions/917.html

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
