### PR TITLE
fix: incorrect CWE for Java file upload filename rule

### DIFF
--- a/rules/java/lang/file_upload_filename.yml
+++ b/rules/java/lang/file_upload_filename.yml
@@ -65,6 +65,6 @@ metadata:
     ## Resources
     - [OWASP path traversal](https://owasp.org/www-community/attacks/Path_Traversal)
   cwe_id:
-    - 22
+    - 73
   id: java_lang_file_upload_filename
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_file_upload_filename


### PR DESCRIPTION
## Description

Fix bad CWE for Java file upload filename rule - here we have unsanitized user input as a filename, which is CWE-73 (External Control of File Name or Path) and not CWE-22 (Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal'))

https://cwe.mitre.org/data/definitions/73.html
https://cwe.mitre.org/data/definitions/22.html

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
