### PR TITLE
feat(java/android): add screenshot prevention rule (CWE-200)

### DIFF
--- a/.github/workflows/canary_integration_tests.yml
+++ b/.github/workflows/canary_integration_tests.yml
@@ -29,6 +29,7 @@ jobs:
             "ruby/third_parties",
             "java/lang",
             "java/spring",
+            "java/android",
             "php/lang",
             "php/symfony",
             "php/third_parties",

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -36,6 +36,7 @@ jobs:
             "ruby/third_parties",
             "java/lang",
             "java/spring",
+            "java/android",
             "php/lang",
             "php/symfony",
             "php/third_parties",

--- a/rules/java/android/prevent_screenshot.yml
+++ b/rules/java/android/prevent_screenshot.yml
@@ -1,0 +1,49 @@
+imports:
+  - java_shared_lang_instance
+patterns:
+  - pattern: |
+      $<GET_WINDOW>.$<METHOD>($<FLAG_SECURE>$<...>);
+    filters:
+      - variable: GET_WINDOW
+        detection: java_android_prevent_screenshot_get_window
+      - variable: METHOD
+        values:
+          - setFlags
+          - addFlags
+      - variable: FLAG_SECURE
+        detection: java_android_prevent_screenshot_flag_secure
+auxiliary:
+  - id: java_android_prevent_screenshot_get_window
+    patterns:
+      - getWindow()
+      - pattern: $<_>.getWindow()
+  - id: java_android_prevent_screenshot_flag_secure
+    patterns:
+      - WindowManager.LayoutParams.FLAG_SECURE;
+languages:
+  - java
+severity: warning
+metadata:
+  description: Permissive screenshot option set
+  remediation_message: |
+    ## Description
+
+    Android may take screenshots of the current application view for display purposes, for example when an application is sent to the background.
+    Whether or not Android is permitted to take such screenshots is determined by the FLAG_SECURE option.
+
+    By default, the FLAG_SECURE option is not set and no screenshots are taken.
+
+    For best security practices, we should not set the FLAG_SECURE to true and we should never allow Android to take screenshots of the current application activity.
+
+    ## Remediations
+
+    ❌ Do not set the FLAG_SECURE option, to ensure that Android does not take screenshots of potentially sensitive information
+
+    ## References
+
+    - []()
+
+  cwe_id:
+    - 200
+  id: java_android_prevent_screenshot
+  documentation_url: https://docs.bearer.com/reference/rules/java_android_prevent_screenshot

--- a/tests/java/android/prevent_screenshot/test.js
+++ b/tests/java/android/prevent_screenshot/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("tapjacking", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/android/prevent_screenshot/testdata/main.java
+++ b/tests/java/android/prevent_screenshot/testdata/main.java
@@ -1,0 +1,13 @@
+public class FlagSecure extends Activity {
+  public void bad() {
+    // bearer:expected java_android_prevent_screenshot
+    getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                         WindowManager.LayoutParams.FLAG_SECURE);
+    // bearer:expected java_android_prevent_screenshot
+    activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+  }
+
+  public void ok() {
+    activity.getWindow().addFlags("some other flag");
+  }
+}


### PR DESCRIPTION
## Description

Add android folder (and update integration test scripts)
Add rule to prevent enabling of screenshots in Android applications

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
