### PR TITLE
feat(java/android): add world readable/writeable rule (CWE-276)

### DIFF
--- a/rules/java/android/world_readable_writable_mode.yml
+++ b/rules/java/android/world_readable_writable_mode.yml
@@ -1,0 +1,31 @@
+patterns:
+  - MODE_WORLD_READABLE;
+  - Context.MODE_WORLD_READABLE;
+  - MODE_WORLD_WRITEABLE;
+  - Context.MODE_WORLD_WRITEABLE;
+languages:
+  - java
+metadata:
+  description: Permissive context mode for resources
+  remediation_message: |
+    ## Description
+
+    Creating world-readable and -writeable files poses a serious security risk.
+    It is for this reason that the `Context.MODE_WORLD_READABLE` and `Context.MODE_WORLD_WRITEABLE` constants were deprecated and later removed.
+
+    ## Remediations
+
+    ✅ Use Context.MODE_PRIVATE wherever possible
+
+    ✅ Use a `ContentProvider` when sharing content with other applications
+
+    ❌ (For legacy applications) Do not use the deprecated `MODE_WORLD_READABLE` or `MODE_WORLD_WRITEABLE` constants
+
+    ## References
+
+    - [Android Context.MODE_PRIVATE reference](https://developer.android.com/reference/android/content/Context#MODE_PRIVATE)
+    - [Android Content Provider reference](https://developer.android.com/reference/android/content/ContentProvider)
+  cwe_id:
+    - 276
+  id: java_android_world_readable_writable_mode
+  documentation_url: https://docs.bearer.com/reference/rules/java_android_world_readable_writable_mode

--- a/tests/java/android/world_readable_writable_mode/test.js
+++ b/tests/java/android/world_readable_writable_mode/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("world_readable_mode", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/android/world_readable_writable_mode/testdata/main.java
+++ b/tests/java/android/world_readable_writable_mode/testdata/main.java
@@ -1,0 +1,9 @@
+// bearer:expected java_android_world_readable_writable_mode
+if ((mode & MODE_WORLD_READABLE) != 0) {
+    perms |= FileUtils.S_IROTH;
+}
+
+File sdDir = new File(Environment.getExternalStorageDirectory(), "mydir");
+// bearer:expected java_android_world_readable_writable_mode
+File filesysDir = getDir("mydir", Context.MODE_WORLD_READABLE);
+File file = new File(sdDir, "myfile.txt");


### PR DESCRIPTION
## Description

Add Android rule around MODE_WORLD_READABLE and MODE_WORLD_WRITEABLE

Note, these constants were deprecated since Android API level 17 and have now been removed but since it's quite a bad one, we add the rule for legacy applications

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
