### PR TITLE
fix: tighten java format string rule

### DIFF
--- a/rules/java/lang/format_string_manipulation.yml
+++ b/rules/java/lang/format_string_manipulation.yml
@@ -6,8 +6,11 @@ patterns:
     filters:
       - variable: USER_INPUT
         detection: java_shared_lang_user_input
-  - pattern: String.format($<_>, $<USER_INPUT>$<...>);
+  - pattern: String.format($<FORMAT_STRING>, $<USER_INPUT>$<...>);
     filters:
+      - not:
+          variable: FORMAT_STRING
+          detection: java_lang_format_string_manipulation_format_string
       - variable: USER_INPUT
         detection: java_shared_lang_user_input
   - pattern: System.out.$<METHOD>($<USER_INPUT>$<...>);
@@ -18,8 +21,11 @@ patterns:
           - printf
       - variable: USER_INPUT
         detection: java_shared_lang_user_input
-  - pattern: System.out.$<METHOD>($<_>, $<USER_INPUT>$<...>);
+  - pattern: System.out.$<METHOD>($<FORMAT_STRING>, $<USER_INPUT>$<...>);
     filters:
+      - not:
+          variable: FORMAT_STRING
+          detection: java_lang_format_string_manipulation_format_string
       - variable: METHOD
         values:
           - format
@@ -36,8 +42,11 @@ patterns:
             regex: \A(java\.util\.)?Formatter\z
       - variable: USER_INPUT
         detection: java_shared_lang_user_input
-  - pattern: $<JAVA_FORMATTER>.format($<_>, $<USER_INPUT>$<...>);
+  - pattern: $<JAVA_FORMATTER>.format($<FORMAT_STRING>, $<USER_INPUT>$<...>);
     filters:
+      - not:
+          variable: FORMAT_STRING
+          detection: java_lang_format_string_manipulation_format_string
       - variable: JAVA_FORMATTER
         detection: java_shared_lang_instance
         scope: cursor
@@ -60,8 +69,11 @@ patterns:
           - printf
       - variable: USER_INPUT
         detection: java_shared_lang_user_input
-  - pattern: $<JAVA_PRINT_STREAM>.$<METHOD>($<_>, $<USER_INPUT>$<...>);
+  - pattern: $<JAVA_PRINT_STREAM>.$<METHOD>($<FORMAT_STRING>, $<USER_INPUT>$<...>);
     filters:
+      - not:
+          variable: FORMAT_STRING
+          detection: java_lang_format_string_manipulation_format_string
       - variable: JAVA_PRINT_STREAM
         detection: java_shared_lang_instance
         scope: cursor
@@ -74,6 +86,13 @@ patterns:
           - printf
       - variable: USER_INPUT
         detection: java_shared_lang_user_input
+auxiliary:
+  - id: java_lang_format_string_manipulation_format_string
+    patterns:
+      - pattern: $<FORMAT_STRING>;
+        filters:
+          - variable: FORMAT_STRING
+            string_regex: (%s)+
 languages:
   - java
 metadata:

--- a/tests/java/lang/format_string_manipulation/testdata/main.java
+++ b/tests/java/lang/format_string_manipulation/testdata/main.java
@@ -41,7 +41,9 @@ public class FooBar extends HttpServlet{
     StringBuilder sb = new StringBuilder();
     Formatter formatter = new Formatter(sb);
 
-    // user input is not the first argument to the formatter
+    // user input is not the format string
     formatter.format("Mish", "Bear", request.getParameter("baz"));
+    formatter.format("Name %s", request.getParameter("baz"));
+    String.format(Locale.US, "Name %s", request.getParameter("baz"));
   }
 }


### PR DESCRIPTION
## Description

We can check for the presence of hard-coded format strings to avoid false positives

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
