### PR TITLE
feat(java): add warning-level rule about socket creation best practices (CWE-319)

### DIFF
--- a/rules/java/lang/socket_init.yml
+++ b/rules/java/lang/socket_init.yml
@@ -1,0 +1,35 @@
+patterns:
+  - pattern: new $<SOCKET>();
+    filters:
+      - variable: SOCKET
+        regex: \A(java\.net\.)?Socket\z
+languages:
+  - java
+severity: warning
+metadata:
+  description: Usage of naive Socket class to create SSL Socket
+  remediation_message: |
+    ## Description
+
+    When creating an SSL socket, it is better security practice to use an SSL Socket factory over `new Socket()`
+    This is because `SSLSocketFactory` has built-in support for SSL/TLS protocols and other security features, such as encryption and support for the configuration of hostname verification and trust managers.
+
+    ## Remediations
+
+    ❌ Where possible, avoid creating SSL sockets using java.net.Socket init as there is limited security support
+
+    ✅ Prefer `SSLSocketFactory` methods to create SSL sockets, something like
+
+    ```java
+      SSLSocketFactory sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+      SSLSocket socket = (SSLSocket) sslSocketFactory.createSocket(socket, host, port, true);
+    ```
+
+    ## References
+
+    - [OWASP Transport Layer Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet.html)
+
+  cwe_id:
+    - 319
+  id: java_lang_socket_init
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_socket_init

--- a/tests/java/lang/socket_init/test.js
+++ b/tests/java/lang/socket_init/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("socket_init", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/socket_init/testdata/main.java
+++ b/tests/java/lang/socket_init/testdata/main.java
@@ -1,0 +1,22 @@
+import java.net.Socket;
+import java.net.SocketFactory;
+
+ public static boolean bad(String host, int port, int timeout) {
+  // bearer:expected java_lang_socket_init
+  try (Socket socket = new Socket()) {
+    socket.connect(new InetSocketAddress(host, port), timeout);
+    return true;
+  } catch (IOException e) {
+    return false;
+  }
+}
+
+private void bad2() {
+  // bearer:expected java_lang_socket_init
+  Socket soc = new java.net.Socket("localhost", 9999);
+}
+
+public Socket ok(String host, int port, InetAddress localAddress, int localPort) throws IOException {
+  SocketFactory socketfactory = getSSLContext().getSocketFactory();
+  return socketfactory.createSocket(host, port, localAddress, localPort);
+}


### PR DESCRIPTION
## Description

Warning-level rule to discourage using Socket init (instead of a SSL Socket Factory) when creating SSL/TLS connections

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
