### PR TITLE
fix: remove unused imports

### DIFF
--- a/rules/java/android/prevent_screenshot.yml
+++ b/rules/java/android/prevent_screenshot.yml
@@ -1,5 +1,3 @@
-imports:
-  - java_shared_lang_instance
 patterns:
   - pattern: |
       $<GET_WINDOW>.$<METHOD>($<FLAG_SECURE>$<...>);


### PR DESCRIPTION
## Description

Clean up - imports is no longer used in this rule so we can remove it

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
