### PR TITLE
fix: cwe for Java insecure allow origin

### DIFF
--- a/rules/java/lang/insecure_allow_origin.yml
+++ b/rules/java/lang/insecure_allow_origin.yml
@@ -44,6 +44,6 @@ metadata:
     ## Resources
     - [OWASP Origin & Access-Control-Allow-Origin](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing)
   cwe_id:
-    - 942
+    - 346
   id: java_lang_insecure_allow_origin
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_insecure_allow_origin


### PR DESCRIPTION
## Description

This rule is CWE-346 - lack of validating allowed origins - and not CWE-942 - overly permissive CORS policy e.g. `allowedOrigins("*")`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
