### PR TITLE
fix: allow origin cwes for php rules

### DIFF
--- a/rules/php/lang/permissive_allow_origin.yml
+++ b/rules/php/lang/permissive_allow_origin.yml
@@ -24,6 +24,6 @@ metadata:
     ## Resources
     - [OWASP Origin & Access-Control-Allow-Origin](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing)
   cwe_id:
-    - 346
+    - 942
   id: php_lang_permissive_allow_origin
   documentation_url: https://docs.bearer.com/reference/rules/php_lang_permissive_allow_origin

--- a/rules/php/symfony/permissive_allow_origin.yml
+++ b/rules/php/symfony/permissive_allow_origin.yml
@@ -46,6 +46,6 @@ metadata:
     ## Resources
     - [OWASP Origin & Access-Control-Allow-Origin](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing)
   cwe_id:
-    - 346
+    - 942
   id: php_symfony_permissive_allow_origin
   documentation_url: https://docs.bearer.com/reference/rules/php_symfony_permissive_allow_origin

--- a/tests/php/lang/permissive_allow_origin/__snapshots__/test.js.snap
+++ b/tests/php/lang/permissive_allow_origin/__snapshots__/test.js.snap
@@ -5,7 +5,7 @@ exports[`php_lang_permissive_allow_origin bad 1`] = `
   "warning": [
     {
       "cwe_ids": [
-        "346"
+        "942"
       ],
       "id": "php_lang_permissive_allow_origin",
       "title": "Permissive Access-Control-Allow-Origin configuration",

--- a/tests/php/symfony/permissive_allow_origin/__snapshots__/test.js.snap
+++ b/tests/php/symfony/permissive_allow_origin/__snapshots__/test.js.snap
@@ -5,7 +5,7 @@ exports[`php_symfony_permissive_allow_origin bad 1`] = `
   "warning": [
     {
       "cwe_ids": [
-        "346"
+        "942"
       ],
       "id": "php_symfony_permissive_allow_origin",
       "title": "Permissive Access-Control-Allow-Origin configuration",
@@ -39,7 +39,7 @@ exports[`php_symfony_permissive_allow_origin bad 1`] = `
     },
     {
       "cwe_ids": [
-        "346"
+        "942"
       ],
       "id": "php_symfony_permissive_allow_origin",
       "title": "Permissive Access-Control-Allow-Origin configuration",


### PR DESCRIPTION
## Description

Permissive CORS is CWE-942 https://cwe.mitre.org/data/definitions/942.html and not CWE-346 which is insecure origins (i.e. user-controlled)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
