### PR TITLE
feat(java): add permissive allow origin rule (CWE-942)

### DIFF
--- a/rules/java/lang/permissive_allow_origin.yml
+++ b/rules/java/lang/permissive_allow_origin.yml
@@ -1,0 +1,43 @@
+imports:
+  - java_shared_lang_instance
+patterns:
+  - pattern: |
+      $<RES>.$<METHOD>($<HEADER>, $<VALUE>);
+    filters:
+      - variable: RES
+        detection: java_shared_lang_instance
+        scope: cursor
+        filters:
+          - variable: JAVA_SHARED_LANG_INSTANCE_TYPE
+            regex: \A(javax\.servlet\.http\.)?HttpServletResponse\z
+      - variable: METHOD
+        values:
+          - setHeader
+          - addHeader
+      - variable: HEADER
+        string_regex: \A(?i)(Access-Control-Allow-Origin)\z
+      - variable: VALUE
+        string_regex: \A\*\z
+languages:
+  - java
+metadata:
+  description: "Permissive Access-Control-Allow-Origin configuration"
+  remediation_message: |
+    ## Description
+    Setting the Access-Control-Allow-Origin header to "*" allows code from any
+    origin to access the response. This can lead to unintended access to
+    sensitive data.
+
+    ## Remediations
+    ✅ Permit only the specific origins needed by your application
+
+    ```php
+    header("Access-Control-Allow-Origin: myapp.example.com");
+    ```
+
+    ## Resources
+    - [OWASP Origin & Access-Control-Allow-Origin](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing)
+  cwe_id:
+    - 942
+  id: java_lang_permissive_allow_origin
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_permissive_allow_origin

--- a/tests/java/lang/permissive_allow_origin/test.js
+++ b/tests/java/lang/permissive_allow_origin/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("permissive_allow_origin", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/permissive_allow_origin/testdata/main.java
+++ b/tests/java/lang/permissive_allow_origin/testdata/main.java
@@ -1,0 +1,56 @@
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class Foo extends HttpServlet {
+  @Override
+  protected void bad(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    String paramValue = request.getParameter("bad");
+    String header = request.getHeader("bad");
+    String queryString = request.getQueryString();
+
+    String[] parameterValues = request.getParameterValues("URL");
+    String indexedParameterValue = parameterValues[0];
+
+    Enumeration<String> parameterNames = request.getParameterNames();
+    String parameterNamesElem = parameterNames.nextElement();
+
+    Map<String, String[]> parameterMap = request.getParameterMap();
+    String indexedValueFromParameterMap = parameterMap.get("URL")[0];
+
+    if (paramValue != null) {
+      // bearer:expected java_lang_permissive_allow_origin
+      response.setHeader("Access-Control-Allow-Origin", "*");
+
+      // bearer:expected java_lang_permissive_allow_origin
+      response.addHeader("Access-Control-Allow-Origin", "*");
+
+      // bearer:expected java_lang_permissive_allow_origin
+      response.setHeader("access-control-allow-origin", "*");
+
+      // bearer:expected java_lang_permissive_allow_origin
+      response.addHeader("access-control-allow-origin", "*");
+
+      String headerName = "ACCESS-CONTROL-ALLOW-ORIGIN";
+      // bearer:expected java_lang_permissive_allow_origin
+      response.addHeader(headerName, "*");
+
+      return;
+    }
+  }
+
+
+  public void badVar(HttpServletRequest request, HttpServletResponse response) throws ServletException {
+    String everythingGoes = "*";
+
+    // bearer:expected java_lang_permissive_allow_origin
+    response.addHeader("Access-Control-Allow-Origin", everythingGoes);
+  }
+
+  public void ok(HttpServletRequest request, HttpServletResponse response) throws ServletException {
+    // set some other header with user-input
+    response.setHeader("X-Example-Header", "*");
+  }
+}


### PR DESCRIPTION
## Description

Add Java rule to catch overly permissive CORS policy (Allow Origin Header set to *)

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
