### PR TITLE
feat(java): regex using user input (CWE-1287)

### DIFF
--- a/rules/java/lang/regex_using_user_input.yml
+++ b/rules/java/lang/regex_using_user_input.yml
@@ -1,0 +1,32 @@
+imports:
+  - java_shared_lang_user_input
+patterns:
+  - pattern: |
+      $<PATTERN>.compile($<USER_INPUT>$<...>)
+    filters:
+      - variable: PATTERN
+        regex: \A(java\.util\.regex\.)?Pattern\z
+      - variable: USER_INPUT
+        detection: java_shared_lang_user_input
+        scope: cursor
+languages:
+  - java
+metadata:
+  description: "Unsanitized user input in regular expression"
+  remediation_message: |
+    ## Description
+
+    Applications should avoid constructing regular expressions from user input.
+    Regular expressions can have exponential worst-case computational
+    complexity, allowing users to trigger this behaviour can result in
+    excessive CPU consumption causing a regular expression denial of service (ReDoS).
+
+    ## Remediations
+    ❌ Avoid using untrusted or user data when building regular expressions
+
+    ## Resources
+    - [OWASP ReDoS attacks explained](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)
+  cwe_id:
+    - 1287
+  id: java_lang_regex_using_user_input
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_regex_using_user_input

--- a/tests/java/lang/regex_using_user_input/test.js
+++ b/tests/java/lang/regex_using_user_input/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("regex_using_user_input", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/regex_using_user_input/testdata/main.java
+++ b/tests/java/lang/regex_using_user_input/testdata/main.java
@@ -1,0 +1,35 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class FooBar {
+  public static void bad(HttpServletRequest request, HttpServletResponse response) {
+    // bearer:expected java_lang_regex_using_user_input
+    Pattern pattern = Pattern.compile(request.getParameter("dangerousRegex"));
+    Matcher matcher = pattern.matcher(request.getParameter("userStr"));
+    if (matcher.matches()) {
+        System.out.println("Match found!");
+    } else {
+        System.out.println("No match found!");
+    }
+  }
+
+  public static void good(String input, String regexStr) {
+    Pattern pattern = Pattern.compile(regexStr);
+    Matcher matcher = pattern.matcher(input);
+    if (matcher.matches()) {
+        System.out.println("Match found!");
+    } else {
+        System.out.println("No match found!");
+    }
+  }
+
+  public static void good(HttpServletRequest request, HttpServletResponse response) {
+    Pattern pattern = Pattern.compile("\A");
+    Matcher matcher = pattern.matcher(request.getParameter("matchMe"));
+    if (matcher.matches()) {
+        System.out.println("Match found!");
+    } else {
+        System.out.println("No match found!");
+    }
+  }
+}


### PR DESCRIPTION
## Description

Add Java rule to catch cases of `Pattern.compile` with user input (susceptible to ReDoS attacks)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
