### PR TITLE
feat(java): vulnerable Apache commons collection version (CWE-1395)

### DIFF
--- a/rules/java/lang/apache_commons_collection.yml
+++ b/rules/java/lang/apache_commons_collection.yml
@@ -6,7 +6,7 @@ patterns:
 dependency_check: true
 dependency:
   name: commons-collections3
-  min_version: 3.2.2
+  min_version: 3.2.1
   filename: maven-dependencies.json
 languages:
   - java

--- a/rules/java/lang/apache_commons_collection.yml
+++ b/rules/java/lang/apache_commons_collection.yml
@@ -1,0 +1,31 @@
+patterns:
+  - pattern: new $<INVOKER_TRANSFORMER>();
+    filters:
+      - variable: INVOKER_TRANSFORMER
+        regex: \A(org\.apache\.commons\.collections\.functors\.)?InvokerTransformer\z
+dependency_check: true
+dependency:
+  name: commons-collections3
+  min_version: 3.2.2
+  filename: maven-dependencies.json
+languages:
+  - java
+metadata:
+  description: Usage of vulnerable Apache Commons Collections 3 class (InvokeTransformer)
+  remediation_message: |
+    ## Description
+
+    The InvokeTransformer class has known security vulnerabilities for versions of Apache Commons Collections older than 3.2.2;
+    namely, the class is vulnerable to remote code execution when deserializing data.
+
+    ## Remediations
+
+    ✅ Upgrade Apache Commons Collections 3 to version 3.2.2 or above
+
+    ## References
+
+    - [Apache Commons Collections 3.2.2](https://commons.apache.org/proper/commons-collections/security-reports.html)
+  cwe_id:
+    - 1395
+  id: java_lang_apache_commons_collection
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_apache_commons_collection

--- a/tests/java/lang/apache_commons_collection/test.js
+++ b/tests/java/lang/apache_commons_collection/test.js
@@ -7,7 +7,16 @@ const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
 describe(ruleId, () => {
   const invoke = createNewInvoker(ruleId, ruleFile, testBase)
 
-  test("apache_commons_collection", () => {
+  test("apache_commons_collection_secure", () => {
+    const testCase = "secure/"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+
+  test("apache_commons_collection_insecure", () => {
     const testCase = "insecure/"
 
     const results = invoke(testCase)

--- a/tests/java/lang/apache_commons_collection/test.js
+++ b/tests/java/lang/apache_commons_collection/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("apache_commons_collection", () => {
+    const testCase = "insecure/"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/apache_commons_collection/testdata/insecure/main.java
+++ b/tests/java/lang/apache_commons_collection/testdata/insecure/main.java
@@ -1,0 +1,9 @@
+import org.apache.commons.collections3;
+
+public class Foo {
+  public static void bad(String[] args) throws Exception {
+    // bearer:expected java_lang_apache_commons_collection
+    InvokerTransformer transformer = new InvokerTransformer("exec", new Class[]{String.class}, new Object[]{"calc.exe"});
+    Object result = transformer.transform(null);
+  }
+}

--- a/tests/java/lang/apache_commons_collection/testdata/insecure/main.java
+++ b/tests/java/lang/apache_commons_collection/testdata/insecure/main.java
@@ -2,7 +2,7 @@ import org.apache.commons.collections3;
 
 public class Foo {
   public static void bad(String[] args) throws Exception {
-    // ok - version 3.2.2 +
+    // bearer:expected java_lang_apache_commons_collection
     InvokerTransformer transformer = new InvokerTransformer("exec", new Class[]{String.class}, new Object[]{"calc.exe"});
     Object result = transformer.transform(null);
   }

--- a/tests/java/lang/apache_commons_collection/testdata/insecure/maven-dependencies.json
+++ b/tests/java/lang/apache_commons_collection/testdata/insecure/maven-dependencies.json
@@ -1,0 +1,10 @@
+[{
+  "groupId": "org.apache.commons",
+  "artifactId": "commons-collections3",
+  "version": "3.2.0"
+},
+{
+  "groupId": "test1",
+  "artifactId": "testartifact1",
+  "version": "1.0.beta"
+}]

--- a/tests/java/lang/apache_commons_collection/testdata/secure/main.java
+++ b/tests/java/lang/apache_commons_collection/testdata/secure/main.java
@@ -2,7 +2,7 @@ import org.apache.commons.collections3;
 
 public class Foo {
   public static void bad(String[] args) throws Exception {
-    // ok - version 3.2.2 +
+    // bearer:expected java_lang_apache_commons_collection
     InvokerTransformer transformer = new InvokerTransformer("exec", new Class[]{String.class}, new Object[]{"calc.exe"});
     Object result = transformer.transform(null);
   }

--- a/tests/java/lang/apache_commons_collection/testdata/secure/main.java
+++ b/tests/java/lang/apache_commons_collection/testdata/secure/main.java
@@ -2,7 +2,7 @@ import org.apache.commons.collections3;
 
 public class Foo {
   public static void bad(String[] args) throws Exception {
-    // bearer:expected java_lang_apache_commons_collection
+    // ok - version 3.2.2 +
     InvokerTransformer transformer = new InvokerTransformer("exec", new Class[]{String.class}, new Object[]{"calc.exe"});
     Object result = transformer.transform(null);
   }

--- a/tests/java/lang/apache_commons_collection/testdata/secure/maven-dependencies.json
+++ b/tests/java/lang/apache_commons_collection/testdata/secure/maven-dependencies.json
@@ -1,0 +1,10 @@
+[{
+  "groupId": "org.apache.commons",
+  "artifactId": "commons-collections3",
+  "version": "3.2.2"
+},
+{
+  "groupId": "test1",
+  "artifactId": "testartifact1",
+  "version": "1.0.beta"
+}]


### PR DESCRIPTION
## Description

Known vulnerability for InvokerTransformer class for commons collections 3 versions older than 3.2.2

https://commons.apache.org/proper/commons-collections/security-reports.html

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
