### PR TITLE
fix: quick solution to handle third parties repo

### DIFF
--- a/scripts/generate_rule.js
+++ b/scripts/generate_rule.js
@@ -14,11 +14,11 @@ const languageInPathToFiles = {
 };
 
 function writeRuleStructure(ruleID) {
-  const ruleNameParts = ruleID.split('_');
+  const ruleNameParts = ruleID.replace("third_parties", "thirdparties").split('_');
   const rootRuleFilePath = path.join(
     'rules',
     ruleNameParts[0],
-    ruleNameParts[1],
+    ruleNameParts[1].replace("thirdparties", "third_parties"),
   );
   try {
     if (!fs.existsSync(rootRuleFilePath)) {
@@ -57,7 +57,7 @@ function writeRuleStructure(ruleID) {
 function writeTestFileIfNotExists(ruleID) {
   try {
     // e.g. ["java", "lang", "log_injection"],join("_")
-    const ruleNameParts = ruleID.split('_');
+    const ruleNameParts = ruleID.replace("third_parties", "thirdparties").split('_');
     const content = `// Use bearer:expected ${ruleID} to flag expected findings`;
     if (ruleNameParts[0] == 'python' || ruleNameParts[0].includes('ruby')) {
       content = `# Use bearer:expected ${ruleID} to flag expected findings`;
@@ -74,7 +74,7 @@ function writeTestFileIfNotExists(ruleID) {
     const rootTestdataFilePath = path.join(
       'tests',
       ruleNameParts[0],
-      ruleNameParts[1],
+      ruleNameParts[1].replace("thirdparties", "third_parties"),
       ruleNameParts.slice(2).join('_'),
     );
 


### PR DESCRIPTION
## Description

Naïve fix to script so we can generate third party rules (different file structure)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
