### PR TITLE
feat(php): improve input sanitizer

### DIFF
--- a/rules/php/shared/lang/user_input_sanitizer.yml
+++ b/rules/php/shared/lang/user_input_sanitizer.yml
@@ -2,6 +2,7 @@ type: shared
 languages:
   - php
 patterns:
+  - (int)$<_>
   - count($<_>)
   - filter_var($<!>$<_>$<...>)
 metadata:

--- a/tests/php/lang/raw_html_using_user_input/testdata/ok.php
+++ b/tests/php/lang/raw_html_using_user_input/testdata/ok.php
@@ -5,3 +5,5 @@ $html = "<h1>$x</h1>";
 $html = "<h1>{$_GET['x'] * $_GET['y']}</h1>";
 
 $html = "<h1>{$ok}</h1>";
+$foo = (int)$_GET['x']
+$html = "<h1>{$foo}</h1>";

--- a/tests/php/lang/raw_output_using_user_input/testdata/echo.php
+++ b/tests/php/lang/raw_output_using_user_input/testdata/echo.php
@@ -21,6 +21,7 @@ echo implode(" and ", $oopsies);
 echo "<h1>" . filter_var($_GET["ok"], FILTER_SANITIZE_STRING) . "</h1>";
 echo strip_tags($_GET["ok"]);
 echo $_GET["x"] + $_GET["y"];
+echo (int)$_GET["x"];
 
 // FIXME: Add support for $this
 $this->Oops = $_POST["oops"];


### PR DESCRIPTION
## Description

Casting to int is a common method to sanitize form variables so we should include it here

## Related
- #172

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
