### PR TITLE
feat(php): add coverage for crc32 and adler32

### DIFF
--- a/rules/php/lang/weak_hash_adler32.yml
+++ b/rules/php/lang/weak_hash_adler32.yml
@@ -1,0 +1,54 @@
+patterns:
+  - pattern: |
+      $<FUNCTION>($<ALGORITHM>$<...>)
+    filters:
+      - variable: FUNCTION
+        values:
+          - hash
+      - variable: ALGORITHM
+        string_regex: adler32
+  - pattern: $<FUNCTION>($<CONTEXT>$<...>)
+    filters:
+      - variable: FUNCTION
+        values:
+          - hash_update_file
+          - hash_update_stream
+          - hash_update
+      - variable: CONTEXT
+        detection: php_lang_weak_hash_crc32_context
+        scope: cursor
+auxiliary:
+  - id: php_lang_weak_hash_crc32_context
+    patterns:
+      - pattern: hash_init($<ALGORITHM>$<...>)
+        filters:
+          - variable: ALGORITHM
+            string_regex: adler32
+languages:
+  - php
+metadata:
+  description: "Usage of weak hashing library (Adler-32)"
+  remediation_message: |
+    ## Description
+
+    While Adler-32 can give a quick assurance of integrity it provides little protection against intentional alteration of data.
+
+    ## Remediations
+
+
+    ❌ Avoid algorithms with known weaknesses:
+
+    ```php
+      $myhash = hash('adler32', $input)
+    ```
+
+    ✅ Use stronger hashing algorithms.
+
+    ```php
+      $myhash = hash('sha256', $input)
+    ```
+
+  cwe_id:
+    - 328
+  id: php_lang_weak_hash_adler32
+  documentation_url: https://docs.bearer.com/reference/rules/php_lang_weak_hash_adler32

--- a/rules/php/lang/weak_hash_crc32.yml
+++ b/rules/php/lang/weak_hash_crc32.yml
@@ -1,0 +1,57 @@
+patterns:
+  - pattern: |
+      crc32($<_>)
+  - pattern: |
+      $<FUNCTION>($<ALGORITHM>$<...>)
+    filters:
+      - variable: FUNCTION
+        values:
+          - hash
+          - hash_hmac
+      - variable: ALGORITHM
+        string_regex: crc32[bc]?
+  - pattern: $<FUNCTION>($<CONTEXT>$<...>)
+    filters:
+      - variable: FUNCTION
+        values:
+          - hash_update
+          - hash_update_file
+          - hash_update_stream
+      - variable: CONTEXT
+        detection: php_lang_weak_hash_crc32_context
+        scope: cursor
+auxiliary:
+  - id: php_lang_weak_hash_crc32_context
+    patterns:
+      - pattern: hash_init($<ALGORITHM>$<...>)
+        filters:
+          - variable: ALGORITHM
+            string_regex: crc32[bc]?
+languages:
+  - php
+metadata:
+  description: "Usage of weak hashing library (CRC32)"
+  remediation_message: |
+    ## Description
+
+    While CRC32 can give a quick assurance of integrity it provides little protection against intentional alteration of data.
+
+    ## Remediations
+
+
+    ❌ Avoid algorithms with known weaknesses:
+
+    ```php
+      $myhash = crc32($input)
+    ```
+
+    ✅ Use stronger hashing algorithms.
+
+    ```php
+      $myhash = hash('sha256', $input)
+    ```
+
+  cwe_id:
+    - 328
+  id: php_lang_weak_hash_crc32
+  documentation_url: https://docs.bearer.com/reference/rules/php_lang_weak_hash_crc32

--- a/tests/php/lang/weak_hash_adler32/test.js
+++ b/tests/php/lang/weak_hash_adler32/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("weak_hash_adler32", () => {
+    const testCase = "index.php"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/php/lang/weak_hash_adler32/testdata/index.php
+++ b/tests/php/lang/weak_hash_adler32/testdata/index.php
@@ -1,0 +1,12 @@
+<?php
+$input = "something important";
+
+$myhash1 = hash('sha256', $input);
+// bearer:expected php_lang_weak_hash_adler32
+$myhash3 = hash('adler32', $input);
+
+$ctx = hash_init('adler32');
+// bearer:expected php_lang_weak_hash_adler32
+hash_update($ctx, $input);
+$myhash4 = hash_final($hasher);
+?>

--- a/tests/php/lang/weak_hash_crc32/test.js
+++ b/tests/php/lang/weak_hash_crc32/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("weak_hash_crc32", () => {
+    const testCase = "index.php"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/php/lang/weak_hash_crc32/testdata/index.php
+++ b/tests/php/lang/weak_hash_crc32/testdata/index.php
@@ -1,0 +1,12 @@
+<?php
+$input = "something important";
+
+$myhash1 = hash('sha256', $input);
+// bearer:expected php_lang_weak_hash_crc32
+$myhash2 = hash('crc32b', $input);
+// bearer:expected php_lang_weak_hash_crc32
+$myhash3 = hash('crc32c', $input);
+// bearer:expected php_lang_weak_hash_crc32
+$myhash4 = crc32($input);
+
+?>


### PR DESCRIPTION
## Description
Add coverage for some of the more common weak hashing algos in PHP. 


## Related
- Close #217


## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [x] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
