### PR TITLE
feat: improve allow origin matching

### DIFF
--- a/rules/php/lang/permissive_allow_origin.yml
+++ b/rules/php/lang/permissive_allow_origin.yml
@@ -3,6 +3,10 @@ patterns:
     filters:
       - variable: VALUE
         string_regex: (?i)\Aaccess-control-allow-origin:\s+\*\s*\z
+  - pattern: $<_>->header($<VALUE>$<...>)
+    filters:
+      - variable: VALUE
+        string_regex: (?i)\Aaccess-control-allow-origin:\s+\*\s*\z
 languages:
   - php
 severity: warning

--- a/tests/php/lang/permissive_allow_origin/__snapshots__/test.js.snap
+++ b/tests/php/lang/permissive_allow_origin/__snapshots__/test.js.snap
@@ -36,6 +36,40 @@ exports[`php_lang_permissive_allow_origin bad 1`] = `
       "fingerprint": "52d1963de02349a5b8871f6b33af0eb6_0",
       "old_fingerprint": "14c32dd4c36dc4cc8d84fd478abbbe7c_0",
       "code_extract": "header(\\"Access-Control-Allow-Origin: *\\", true);"
+    },
+    {
+      "cwe_ids": [
+        "942"
+      ],
+      "id": "php_lang_permissive_allow_origin",
+      "title": "Permissive Access-Control-Allow-Origin configuration",
+      "description": "## Description\\nSetting the Access-Control-Allow-Origin header to \\"*\\" allows code from any\\norigin to access the response. This can lead to unintended access to\\nsensitive data.\\n\\n## Remediations\\n✅ Permit only the specific origins needed by your application\\n\\n\`\`\`php\\nheader(\\"Access-Control-Allow-Origin: myapp.example.com\\");\\n\`\`\`\\n\\n## Resources\\n- [OWASP Origin & Access-Control-Allow-Origin](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/11-Client-side_Testing/07-Testing_Cross_Origin_Resource_Sharing)\\n",
+      "documentation_url": "https://docs.bearer.com/reference/rules/php_lang_permissive_allow_origin",
+      "line_number": 4,
+      "full_filename": "/tmp/bearer-scan/bad.php",
+      "filename": ".",
+      "source": {
+        "start": 4,
+        "end": 4,
+        "column": {
+          "start": 1,
+          "end": 78
+        }
+      },
+      "sink": {
+        "start": 4,
+        "end": 4,
+        "column": {
+          "start": 1,
+          "end": 78
+        },
+        "content": "$output->getRequest()->response()->header( 'Access-Control-Allow-Origin: *' )"
+      },
+      "parent_line_number": 4,
+      "snippet": "$output->getRequest()->response()->header( 'Access-Control-Allow-Origin: *' )",
+      "fingerprint": "52d1963de02349a5b8871f6b33af0eb6_1",
+      "old_fingerprint": "14c32dd4c36dc4cc8d84fd478abbbe7c_1",
+      "code_extract": "$output->getRequest()->response()->header( 'Access-Control-Allow-Origin: *' );"
     }
   ]
 }"

--- a/tests/php/lang/permissive_allow_origin/testdata/bad.php
+++ b/tests/php/lang/permissive_allow_origin/testdata/bad.php
@@ -1,3 +1,6 @@
 <?php
 
 header("Access-Control-Allow-Origin: *", true);
+$output->getRequest()->response()->header( 'Access-Control-Allow-Origin: *' );
+
+?>

--- a/tests/php/lang/permissive_allow_origin/testdata/ok.php
+++ b/tests/php/lang/permissive_allow_origin/testdata/ok.php
@@ -2,3 +2,5 @@
 
 header("Access-Control-Allow-Origin: $ok", true);
 header("Access-Control-Allow-Origin: foo", true);
+
+?>


### PR DESCRIPTION
## Description
Improve `php_lang_permissive_allow_origin` coverage

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [x] I've added a snapshot that shows my rule works as expected.
- [x] My rule has adequate metadata to explain its use.
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
