### PR TITLE
feat(java): add third parties open telemetry

### DIFF
--- a/rules/java/third_parties/open_telemetry.yml
+++ b/rules/java/third_parties/open_telemetry.yml
@@ -1,0 +1,42 @@
+imports:
+  - java_shared_lang_datatype
+patterns:
+  - pattern: $<SPAN>.setAttribute($<...>$<DATA_TYPE>$<...>);
+    filters:
+      - variable: SPAN
+        detection: java_third_parties_open_telemetry_span
+      - variable: DATA_TYPE
+        detection: java_shared_lang_datatype
+auxiliary:
+  - id: java_third_parties_open_telemetry_span
+    patterns:
+      - pattern: $<SPAN>;
+        filters:
+          - variable: SPAN
+            regex: \A(io\.opentelemetry\.api\.trace\.)?Span\z
+      - pattern: $<SPAN>.current();
+        filters:
+          - variable: SPAN
+            regex: \A(io\.opentelemetry\.api\.trace\.)?Span\z
+languages:
+  - java
+skip_data_types:
+  - "Unique Identifier"
+metadata:
+  description: Leakage of sensitive data to Open Telemetry
+  remediation_message: |
+    ## Description
+    Leaking sensitive data to third-party loggers is a common cause of data
+    leaks and can lead to data breaches. This rule looks for instances of
+    sensitive data sent to Open Telemetry.
+
+    ## Remediations
+
+    When logging errors or events, ensure all sensitive data is removed.
+
+    ## Resources
+    - [Open Telemetry Docs](https://opentelemetry.io/docs/)
+  cwe_id:
+    - 201
+  id: java_third_parties_open_telemetry
+  documentation_url: https://docs.bearer.com/reference/rules/java_third_parties_open_telemetry

--- a/tests/java/third_parties/open_telemetry/test.js
+++ b/tests/java/third_parties/open_telemetry/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("open_telemetry", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/third_parties/open_telemetry/testdata/main.java
+++ b/tests/java/third_parties/open_telemetry/testdata/main.java
@@ -1,0 +1,46 @@
+// Use bearer:expected java_third_parties_open_telemetry to flag expected findings
+package io.opentelemetry.example.tracing;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.extension.incubator.trace.ExtendedTracer;
+
+public class Foo {
+  public bad(User user) {
+    // ...
+    // bearer:expected java_third_parties_open_telemetry
+    Span.current().setAttribute("userId", user.email);
+    // ...
+  }
+
+  public bad2(User user) {
+    // ...
+    Span span = Span.current();
+    // bearer:expected java_third_parties_open_telemetry
+    span.setAttribute("userId", user.email);
+    // ...
+  }
+
+  public bad3(User user) {
+    // ...
+    Tracer tracer = openTelemetry.getTracer("io.opentelemetry.example.http.HttpClient");
+    Span span = tracer.spanBuilder("/").setSpanKind(SpanKind.CLIENT).startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      // bearer:expected java_third_parties_open_telemetry
+      span.setAttribute("userId", user.email);
+    }
+    // ...
+  }
+
+  public good(User user) {
+    // ...
+    Tracer tracer = openTelemetry.getTracer("io.opentelemetry.example.http.HttpClient");
+    Span span = tracer.spanBuilder("/").setSpanKind(SpanKind.CLIENT).startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      span.setAttribute("userId", user.uuid);
+    }
+    // ...
+  }
+}


### PR DESCRIPTION
## Description

Add third party Java rule for Open Telemetry

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
