### PR TITLE
feat(go): deserialization of user input (CWE-502)

### DIFF
--- a/rules/go/lang/deserialization_of_user_input.yml
+++ b/rules/go/lang/deserialization_of_user_input.yml
@@ -1,0 +1,61 @@
+imports:
+  - go_shared_lang_dynamic_request_input
+patterns:
+  - pattern: $<DECODER>.Decode($<USER_INPUT>);
+    filters:
+      - variable: DECODER
+        detection: go_lang_deserialization_of_user_input_decoder
+      - variable: USER_INPUT
+        detection: go_shared_lang_dynamic_request_input
+  - pattern: $<ENCODER>.Encode($<...>$<USER_INPUT>$<...>);
+    filters:
+      - variable: ENCODER
+        detection: go_lang_deserialization_of_user_input_encoder
+      - variable: USER_INPUT
+        detection: go_shared_lang_dynamic_request_input
+  - pattern: $<CALLER>.$<METHOD>($<...>$<USER_INPUT>$<...>);
+    filters:
+      - variable: CALLER
+        values:
+          - yaml
+          - json
+          - proto
+      - variable: METHOD
+        values:
+          - Unmarshal
+          - Marshal
+      - variable: USER_INPUT
+        detection: go_shared_lang_dynamic_request_input
+auxiliary:
+  - id: go_lang_deserialization_of_user_input_decoder
+    patterns:
+      - gob.NewDecoder();
+      - json.NewDecoder();
+  - id: go_lang_deserialization_of_user_input_encoder
+    patterns:
+      - gob.NewEncoder();
+      - json.NewEncoder();
+languages:
+  - go
+metadata:
+  description: Unsanitized user input in deserialization method
+  remediation_message: |
+    ## Description
+
+    It is bad practice to deserialize untrusted data, such as data that comes
+    from external sources like user input or request parameters, without sufficient
+    verification. Attackers can transfer payloads or malicious code via serialized
+    data, and deserializing such data puts your application at risk.
+
+    ## Remediations
+
+    ❌ Do not deserialize untrusted data
+
+    ✅ Validate and sanitize data before attempting to (de)serialize it
+
+    ## Resources
+    - [OWASP Deserialization cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html)
+  cwe_id:
+    - 502
+  id: go_lang_deserialization_of_user_input
+  documentation_url: https://docs.bearer.com/reference/rules/go_lang_deserialization_of_user_input

--- a/tests/go/lang/deserialization_of_user_input/test.js
+++ b/tests/go/lang/deserialization_of_user_input/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("deserialization_of_user_input", () => {
+    const testCase = "main.go"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/go/lang/deserialization_of_user_input/testdata/main.go
+++ b/tests/go/lang/deserialization_of_user_input/testdata/main.go
@@ -1,0 +1,41 @@
+// Use bearer:expected go_lang_deserialization_of_user_input to flag expected findings
+
+import (
+	"encoding/gob"
+	"gopkg.in/yaml.v3"
+	"github.com/golang/protobuf/proto"
+	"bytes"
+	"fmt"
+)
+
+func bad() {
+	decoder := gob.NewDecoder(os.Args[0])
+	// bearer:expected go_lang_deserialization_of_user_input
+	decoder.Decode(os.Args[0])
+	// ...
+}
+
+func bad2() {
+	// bearer:expected go_lang_deserialization_of_user_input
+	yaml.Unmarshal(os.Args[0])
+	// bearer:expected go_lang_deserialization_of_user_input
+	yaml.Marshal(os.Args[0])
+	// ...
+}
+
+func bad3() {
+	// bearer:expected go_lang_deserialization_of_user_input
+	json.Unmarshal(os.Args[0])
+	// bearer:expected go_lang_deserialization_of_user_input
+	json.Marshal(os.Args[0])
+	// ...
+}
+
+func bad4() {
+	newMessage := &example.Message{}
+	// bearer:expected go_lang_deserialization_of_user_input
+	proto.Unmarshal(os.Args[0], newMessage)
+	// bearer:expected go_lang_deserialization_of_user_input
+	proto.Marshal(os.Args[0])
+	// ...
+}


### PR DESCRIPTION
## Description

Add Golang deserialization of external input rule

Relates to #271 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
