### PR TITLE
feat(go): permissive regexp (CWE-625)

### DIFF
--- a/rules/go/lang/permissive_regex_validation.yml
+++ b/rules/go/lang/permissive_regex_validation.yml
@@ -1,0 +1,55 @@
+patterns:
+  - pattern: |
+      $<REGEXP>.$<METHOD>($<PATTERN>$<...>)
+    filters:
+      - variable: REGEXP
+        detection: go_lang_permissive_regex_validation_regexp
+      - variable: METHOD
+        values:
+          - Compile
+          - MustCompile
+      - not:
+          variable: PATTERN
+          string_regex: \A.\\A.*\\[zZ].\z
+auxiliary:
+  - id: go_lang_permissive_regex_validation_regexp
+    patterns:
+      - import $<!>"regexp"
+      - |
+        import (
+          $<!>"regexp"
+        )
+languages:
+  - go
+metadata:
+  description: ""
+  remediation_message: |
+    ## Description
+
+    Validations using regular expressions should use the start of text (\A) and
+    end of text (\z or \Z) boundaries.
+
+    ## Remediations
+
+    ❌ Avoid matching without start and end boundaries:
+
+    ```go
+    regexp.MustCompile("foo")
+    ```
+
+    ❌ Avoid using line-based boundaries:
+
+    ```go
+    regexp.MustCompile("^foo$"}
+    ```
+
+    ✅ Use whole-text boundaries:
+
+    ```go
+    regexp.MustCompile("\Afoo\z")
+    ```
+
+  cwe_id:
+    - 625
+  id: go_lang_permissive_regex_validation
+  documentation_url: https://docs.bearer.com/reference/rules/go_lang_permissive_regex_validation

--- a/tests/go/lang/permissive_regex_validation/test.js
+++ b/tests/go/lang/permissive_regex_validation/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("permissive_regex_validation", () => {
+    const testCase = "main.go"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/go/lang/permissive_regex_validation/testdata/main.go
+++ b/tests/go/lang/permissive_regex_validation/testdata/main.go
@@ -1,0 +1,15 @@
+// Use bearer:expected go_lang_permissive_regex_validation to flag expected findings
+package main
+
+import (
+	"regexp"
+)
+
+func bad() {
+	// bearer:expected go_lang_permissive_regex_validation
+	_ = regexp.MustCompile("[a-zA-Z0-9]*")
+}
+
+func good() {
+	_ = regexp.MustCompile(`\A[a-zA-Z0-9]*\z`)
+}


### PR DESCRIPTION
## Description

Add golang rule to catch regular expressions missing boundaries

Relates to #271 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] I've added a snapshot that shows my rule works as expected.
- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
