### PR TITLE
feat(js): add deserialization rule

### DIFF
--- a/rules/javascript/lang/unsafe_deserialization.yml
+++ b/rules/javascript/lang/unsafe_deserialization.yml
@@ -1,0 +1,46 @@
+imports:
+  - javascript_shared_common_user_input
+patterns:
+  - pattern: |
+      $<YAML>.$<METHOD>($<USER_INPUT>$<...>)
+    filters:
+      - variable: YAML
+        regex: \A(?i)yaml\z
+      - variable: METHOD
+        values:
+          # yaml
+          - parse
+          - parseDocument
+          - parseAllDocuments
+          # yaml-js
+          - load
+          - loadAll
+      - variable: USER_INPUT
+        detection: javascript_shared_common_user_input
+        scope: result
+languages:
+  - javascript
+metadata:
+  description: Unsanitized user input in deserialization method
+  remediation_message: |
+    ## Description
+    It is bad practice to deserialize (unmarshal) untrusted data, such as data direct from the request object.
+    Attackers can transfer payloads or malicious code via serialized data, and deserializing such data puts your application at risk.
+
+    ## Remediations
+    ❌ Do not deserialize untrusted data
+
+    ✅ Prefer pure (data-only) and language-agnostic (de)serialization formats such as JSON or XML
+
+    Avoiding language-specific (de)serialization formats reduces the risk of attackers manipulating the deserialization process for malicious purposes.
+
+    ```javascript
+      JSON.parse(req.params)
+    ```
+
+    ## Resources
+    - [OWASP Deserialization cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html)
+  cwe_id:
+    - 502
+  id: javascript_lang_unsafe_deserialization
+  documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_unsafe_deserialization

--- a/tests/javascript/lang/unsafe_deserialization/test.js
+++ b/tests/javascript/lang/unsafe_deserialization/test.js
@@ -1,0 +1,18 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("unsafe_deserialization", () => {
+    const testCase = "app.js"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/javascript/lang/unsafe_deserialization/testdata/app.js
+++ b/tests/javascript/lang/unsafe_deserialization/testdata/app.js
@@ -1,0 +1,14 @@
+const YAML = require('yaml');
+const yaml = require('js-yaml');
+
+// bearer:expected javascript_lang_unsafe_deserialization
+YAML.parse(`/path/${req.params.yamlFilePath}`)
+// bearer:expected javascript_lang_unsafe_deserialization
+YAML.parseDocument(req.params.yamlFilePath)
+// bearer:expected javascript_lang_unsafe_deserialization
+const obj = yaml.load(`/path/${req.params.yamlFilePath}`);
+
+// ok
+yaml.load("known/path")
+// ok
+YAML.parse({hello: "world"})


### PR DESCRIPTION
## Description

Add deserialization rule around YAML parsing for JS lang

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
