### PR TITLE
fix(js): extend and add open redirect rules

### DIFF
--- a/.github/workflows/canary_integration_tests.yml
+++ b/.github/workflows/canary_integration_tests.yml
@@ -21,6 +21,7 @@ jobs:
         group:
           [
             "javascript/express",
+            "javascript/hapi",
             "javascript/lang",
             "javascript/react",
             "javascript/third_parties",

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,6 +28,7 @@ jobs:
         group:
           [
             "javascript/express",
+            "javascript/hapi",
             "javascript/lang",
             "javascript/react",
             "javascript/third_parties",

--- a/rules/javascript/hapi/open_redirect.yml
+++ b/rules/javascript/hapi/open_redirect.yml
@@ -1,0 +1,57 @@
+imports:
+  - javascript_shared_common_user_input
+patterns:
+  - pattern: |
+      $<RES>.redirect($<USER_INPUT>$<...>)
+    filters:
+      - variable: RES
+        detection: javascript_hapi_open_redirect_response_toolkit
+      - variable: USER_INPUT
+        detection: javascript_shared_common_user_input
+        scope: result
+auxiliary:
+  - id: javascript_hapi_open_redirect_response_toolkit
+    patterns:
+      - responseToolkit
+      # typescript
+      - |
+        const $<_>: ResponseToolkit = $<!>$<_>
+      - |
+        ($<...>$<!>$<_>: ResponseToolkit$<...>) => {}
+      - |
+        ($<...>$<!>$<_>: ResponseToolkit$<...>) {}
+      - |
+        function ($<...>$<!>$<_>: ResponseToolkit$<...>) {}
+      - |
+        function $<_>($<...>$<!>$<_>: ResponseToolkit$<...>) {}
+      - |
+        class $<_> $<...>{ $<...>$<_>($<...>$<!>$<_>: ResponseToolkit$<...>) {} }
+languages:
+  - javascript
+severity: medium
+metadata:
+  description: Unsanitized user input in redirect
+  remediation_message: |
+    ## Description
+    A redirect using unsanitized user input is bad practice and puts your application at greater risk of phishing attacks.
+
+    ## Remediations
+    ❌ Do not use unsanitized user input when constructing URLs
+
+    ✅ Instead, ensure the input is validated by using a safe list or a mapping when constructing URLs
+
+    ```javascript
+      var map = {
+        "1": "/planes",
+        "2": "/trains",
+        "3": "/automobiles",
+      }
+
+      res.redirect(map[req.body.transport])
+    ```
+    ## Resources
+    - [OWASP open redirect](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html)
+  cwe_id:
+    - 601
+  id: javascript_hapi_open_redirect
+  documentation_url: https://docs.bearer.com/reference/rules/javascript_hapi_open_redirect

--- a/rules/javascript/shared/express/user_input.yml
+++ b/rules/javascript/shared/express/user_input.yml
@@ -14,6 +14,7 @@ patterns:
           - headers
           - params
           - query
+          - url
   - pattern: const { $<!>$<PROPERTY> } = $<REQUEST>
     filters:
       - variable: REQUEST
@@ -26,6 +27,7 @@ patterns:
           - headers
           - params
           - query
+          - url
   # typescript
   - pattern: |
       const { $<!>$<PROPERTY> }: Request = $<_>
@@ -37,6 +39,7 @@ patterns:
           - headers
           - params
           - query
+          - url
   - pattern: |
       ($<...>{ $<!>$<PROPERTY> }: Request$<...>) => {}
     filters:
@@ -47,6 +50,7 @@ patterns:
           - headers
           - params
           - query
+          - url
   - pattern: |
       function ($<...>{ $<!>$<PROPERTY> }: Request$<...>) {}
     filters:
@@ -57,6 +61,7 @@ patterns:
           - headers
           - params
           - query
+          - url
   - pattern: |
       function $<_>($<...>{ $<!>$<PROPERTY> }: Request$<...>) {}
     filters:
@@ -67,6 +72,7 @@ patterns:
           - headers
           - params
           - query
+          - url
   - pattern: |
       class $<_> $<...>{ $<_>($<...>{ $<!>$<PROPERTY> }: Request$<...>) {} }
     filters:
@@ -77,6 +83,7 @@ patterns:
           - headers
           - params
           - query
+          - url
 auxiliary:
   - id: javascript_shared_express_user_input_request
     patterns:
@@ -86,6 +93,8 @@ auxiliary:
         const $<_>: Request = $<!>$<_>
       - |
         ($<...>$<!>$<_>: Request$<...>) => {}
+      - |
+        ($<...>$<!>$<_>: Request$<...>) {}
       - |
         function ($<...>$<!>$<_>: Request$<...>) {}
       - |

--- a/tests/javascript/express/open_redirect/test.js
+++ b/tests/javascript/express/open_redirect/test.js
@@ -7,7 +7,7 @@ const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
 describe(ruleId, () => {
   const invoke = createNewInvoker(ruleId, ruleFile, testBase)
 
-  
+
     test("ok_no_open_redirect", () => {
       const testCase = "ok_no_open_redirect.js"
 
@@ -16,7 +16,7 @@ describe(ruleId, () => {
       expect(results.Missing).toEqual([])
       expect(results.Extra).toEqual([])
     })
-  
+
 
     test("open_redirect", () => {
       const testCase = "open_redirect.js"
@@ -26,5 +26,14 @@ describe(ruleId, () => {
       expect(results.Missing).toEqual([])
       expect(results.Extra).toEqual([])
     })
-  
+
+    test("open_redirect_ts", () => {
+      const testCase = "app.ts"
+
+      const results = invoke(testCase)
+
+      expect(results.Missing).toEqual([])
+      expect(results.Extra).toEqual([])
+    })
+
 })

--- a/tests/javascript/express/open_redirect/testdata/app.ts
+++ b/tests/javascript/express/open_redirect/testdata/app.ts
@@ -1,0 +1,12 @@
+import { format as formatUrl } from 'url';
+
+export class Foo {
+  public async bad(req: Request, res: Response) {
+    // bearer:expected javascript_express_open_redirect
+    return res.redirect(formatUrl({
+          pathname: req.url.pathname
+        })
+      )
+      .takeover();
+  }
+}

--- a/tests/javascript/hapi/open_redirect/test.js
+++ b/tests/javascript/hapi/open_redirect/test.js
@@ -1,0 +1,27 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("open_redirect_js", () => {
+    const testCase = "app.js"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+
+  test("open_redirect_ts", () => {
+    const testCase = "app.ts"
+
+    const results = invoke(testCase)
+
+    expect(results.Missing).toEqual([])
+    expect(results.Extra).toEqual([])
+  })
+})

--- a/tests/javascript/hapi/open_redirect/testdata/app.js
+++ b/tests/javascript/hapi/open_redirect/testdata/app.js
@@ -1,0 +1,14 @@
+import { Request, ResponseToolkit } from "@hapi/hapi";
+import { format as formatUrl } from 'url';
+
+export class Foo {
+  async bad(req, responseToolkit) {
+    // bearer:expected javascript_hapi_open_redirect
+    return responseToolkit
+      .redirect(formatUrl({
+          pathname: req.url.pathname
+        })
+      )
+      .takeover();
+  }
+}

--- a/tests/javascript/hapi/open_redirect/testdata/app.ts
+++ b/tests/javascript/hapi/open_redirect/testdata/app.ts
@@ -1,0 +1,14 @@
+import { Request, ResponseToolkit } from "@hapi/hapi";
+import { format as formatUrl } from 'url';
+
+export class Foo {
+  public async bad(req: Request, res: ResponseToolkit) {
+    // bearer:expected javascript_hapi_open_redirect
+    return res
+      .redirect(formatUrl({
+          pathname: req.url.pathname
+        })
+      )
+      .takeover();
+  }
+}


### PR DESCRIPTION
## Description

Extend express open redirect rule

Add hapi as a new framework folder
Add hapi open redirect rule

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
