### PR TITLE
fix: open redirect js rules

### DIFF
--- a/rules/javascript/express/open_redirect.yml
+++ b/rules/javascript/express/open_redirect.yml
@@ -2,11 +2,31 @@ imports:
   - javascript_shared_common_user_input
 patterns:
   - pattern: |
-      res.redirect($<USER_INPUT>$<...>)
+      $<RES>.redirect($<USER_INPUT>$<...>)
     filters:
+      - variable: RES
+        detection: javascript_express_open_redirect_response
       - variable: USER_INPUT
         detection: javascript_shared_common_user_input
         scope: result
+auxiliary:
+  - id: javascript_express_open_redirect_response
+    patterns:
+      - res
+      - response
+      # typescript
+      - |
+        const $<_>: Response = $<!>$<_>
+      - |
+        ($<...>$<!>$<_>: Response$<...>) => {}
+      - |
+        ($<...>$<!>$<_>: Response$<...>) {}
+      - |
+        function ($<...>$<!>$<_>: Response$<...>) {}
+      - |
+        function $<_>($<...>$<!>$<_>: Response$<...>) {}
+      - |
+        class $<_> $<...>{ $<...>$<_>($<...>$<!>$<_>: Response$<...>) {} }
 languages:
   - javascript
 severity: medium

--- a/rules/javascript/hapi/open_redirect.yml
+++ b/rules/javascript/hapi/open_redirect.yml
@@ -4,6 +4,12 @@ patterns:
   - pattern: |
       $<RES>.redirect($<USER_INPUT>$<...>)
     filters:
+      - not:
+          # avoid overlap with express js rule
+          variable: RES
+          values:
+            - res
+            - response
       - variable: RES
         detection: javascript_hapi_open_redirect_response_toolkit
       - variable: USER_INPUT

--- a/rules/javascript/shared/express/user_input.yml
+++ b/rules/javascript/shared/express/user_input.yml
@@ -88,6 +88,7 @@ auxiliary:
   - id: javascript_shared_express_user_input_request
     patterns:
       - req
+      - request
       # typescript
       - |
         const $<_>: Request = $<!>$<_>

--- a/tests/javascript/hapi/open_redirect/testdata/app.ts
+++ b/tests/javascript/hapi/open_redirect/testdata/app.ts
@@ -1,12 +1,12 @@
-import { Request, ResponseToolkit } from "@hapi/hapi";
+import { Server, Request, ResponseToolkit } from "@hapi/hapi";
 import { format as formatUrl } from 'url';
 
 export class Foo {
-  public async bad(req: Request, res: ResponseToolkit) {
+  public async bad(request: Request, responseToolkit: ResponseToolkit) {
     // bearer:expected javascript_hapi_open_redirect
-    return res
+    return responseToolkit
       .redirect(formatUrl({
-          pathname: req.url.pathname
+          pathname: request.url.pathname
         })
       )
       .takeover();


### PR DESCRIPTION
## Description

* Naïve prevention of duplicates between hapi and express open redirect rules
* Add `request` fallback to user input

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
