### PR TITLE
feat(java): extend hardcoded secret rule

### DIFF
--- a/rules/java/lang/hardcoded_secret.yml
+++ b/rules/java/lang/hardcoded_secret.yml
@@ -18,16 +18,24 @@ patterns:
       - variable: STRING_LITERAL
         detection: java_lang_hardcoded_secret_literal
         scope: cursor
-  - pattern: $<...>char[] $<NAME> = {};
+  - pattern: $<...>$<TYPE>[] $<NAME> = {};
     filters:
+      - variable: TYPE
+        values:
+          - char
+          - String
       - variable: NAME
         detection: java_lang_hardcoded_secret_name
         scope: cursor_strict
   - pattern: |
       class $<...>$<_> $<...> {
-        $<!>$<...>char[] $<NAME> = {};
+        $<!>$<...>$<TYPE>[] $<NAME> = {};
       }
     filters:
+      - variable: TYPE
+        values:
+          - char
+          - String
       - variable: NAME
         detection: java_lang_hardcoded_secret_name
         scope: cursor_strict
@@ -49,9 +57,13 @@ patterns:
       - variable: NAME
         detection: java_lang_hardcoded_secret_name
         scope: cursor_strict
-      - variable: STRING_LITERAL
-        detection: java_lang_hardcoded_secret_literal
-        scope: cursor
+      - either:
+          - variable: STRING_LITERAL
+            detection: java_lang_hardcoded_secret_literal
+            scope: cursor
+          - variable: STRING_LITERAL
+            detection: java_lang_hardcoded_secret_base64_literal
+            scope: cursor
   - pattern: |
       class $<...>$<_> $<...> {
         $<!>$<...>String $<NAME> = $<STRING_LITERAL>;
@@ -60,9 +72,21 @@ patterns:
       - variable: NAME
         detection: java_lang_hardcoded_secret_name
         scope: cursor_strict
+      - either:
+          - variable: STRING_LITERAL
+            detection: java_lang_hardcoded_secret_literal
+            scope: cursor
+          - variable: STRING_LITERAL
+            detection: java_lang_hardcoded_secret_base64_literal
+            scope: cursor
+  - pattern: $<STRING_LITERAL>.equals($<NAME>);
+    filters:
       - variable: STRING_LITERAL
         detection: java_lang_hardcoded_secret_literal
         scope: cursor
+      - variable: NAME
+        detection: java_lang_hardcoded_secret_name
+        scope: cursor_strict
 auxiliary:
   - id: java_lang_hardcoded_secret_name
     patterns:
@@ -85,11 +109,25 @@ auxiliary:
               string_regex: \A[*•]+\z
           - variable: STRING
             entropy_greater_than: 3.5
+  - id: java_lang_hardcoded_secret_base64_literal
+    patterns:
+      # TextCodec used for JWTs
+      - pattern: $<TEXT_CODEC>.$<BASE64>.encode($<STRING_LITERAL>);
+        filters:
+          - variable: TEXT_CODEC
+            regex: \A(io\.jsonwebtoken\.impl\.)?TextCodec\z
+          - variable: BASE64
+            values:
+              - BASE64
+              - BASE64URL
+          - variable: STRING_LITERAL
+            detection: java_lang_hardcoded_secret_literal
+            scope: cursor
 languages:
   - java
 severity: high
 metadata:
-  description: "Hard-coded secret detected"
+  description: Hard-coded secret detected
   remediation_message: |
     ## Description
 

--- a/tests/java/lang/hardcoded_secret/testdata/main.java
+++ b/tests/java/lang/hardcoded_secret/testdata/main.java
@@ -13,7 +13,12 @@ public class ShareTheSecrets {
   // bearer:expected java_lang_hardcoded_secret
   private static final char[] password = { 's', 'e', 'c', 'r', 'e', 't', '5' };
   // bearer:expected java_lang_hardcoded_secret
+  public static final String[] SECRETS = {"secret", "admin", "password", "123456", "passw0rd"};
+  // bearer:expected java_lang_hardcoded_secret
   public static final String API_KEY = ".uYikE-os3cM23rz.i6Q";
+
+  // bearer:expected java_lang_hardcoded_secret
+  public static final String JWT_PASSWORD = TextCodec.BASE64.encode("6sGVjfiD0iPLux5fyuDxorRMG4qyNi7U3cQ");
 
   public static void bad() throws Exception {
     // bearer:expected java_lang_hardcoded_secret
@@ -31,6 +36,13 @@ public class ShareTheSecrets {
     public char[] apiKey = {"s", "e", "c", "r", "e", "t"};
     // bearer:expected java_lang_hardcoded_secret
     char[] pwd = ".uYikE-os3cM23rz.i6Q".toCharArray();
+  }
+
+  public void stillBad(String password) {
+    // bearer:expected java_lang_hardcoded_secret
+    if ("xFb8H9qoPVabx6QvUQygMIOS69nsgh1LQkb".equals(password)) {
+      // let them in
+    }
   }
 
   public void good() throws Exception {


### PR DESCRIPTION
## Description

Extend hardcoded secret rule to include the following 3 cases

* String collections (e.g. `String[] SECRETS = { "hello", "world" }`)
* Base64 encoded JWT tokens - such weak encoding is arguable plaintext
* Equality tests against hardcoded password strings

Relates to #197 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
