### PR TITLE
feat(java): add xxe rule

### DIFF
--- a/rules/java/lang/xml_external_entity_vulnerability.yml
+++ b/rules/java/lang/xml_external_entity_vulnerability.yml
@@ -1,0 +1,132 @@
+imports:
+  - java_shared_lang_user_input
+patterns:
+  - pattern: $<DOCUMENT_BUILDER>.parse($<XML_INPUT>$<...>)
+    filters:
+      - variable: DOCUMENT_BUILDER
+        detection: java_lang_xml_external_entity_vulnerability_document_builder
+      - either:
+          - variable: XML_INPUT
+            detection: java_lang_xml_external_entity_vulnerability_input_stream
+            scope: cursor
+          - variable: XML_INPUT
+            detection: java_lang_xml_external_entity_vulnerability_file
+            scope: cursor
+  - pattern: $<UNMARSHALLER>.unmarshal($<XML_INPUT>$<...>)
+    filters:
+      - variable: UNMARSHALLER
+        detection: java_lang_xml_external_entity_vulnerability_unmarshaller
+      - either:
+          - variable: XML_INPUT
+            detection: java_shared_lang_user_input
+            scope: cursor
+          - variable: XML_INPUT
+            detection: java_lang_xml_external_entity_vulnerability_input_stream
+            scope: cursor
+          - variable: XML_INPUT
+            detection: java_lang_xml_external_entity_vulnerability_file
+            scope: cursor
+          - variable: XML_INPUT
+            detection: java_lang_xml_external_entity_vulnerability_url
+            scope: cursor
+          - variable: XML_INPUT
+            detection: java_lang_xml_external_entity_vulnerability_stream_source
+            scope: cursor
+auxiliary:
+  - id: java_lang_xml_external_entity_vulnerability_input_stream
+    patterns:
+      - pattern: $<_> $<INPUT_STREAM> = new $<INPUT_STREAM_CLASS>($<USER_INPUT>$<...>);
+        focus: INPUT_STREAM
+        filters:
+          - variable: INPUT_STREAM_CLASS
+            regex: \A(java\.io\.)?(InputStream|ByteArrayInputStream|FileInputStream|StringBufferInputStream)\z
+          - variable: USER_INPUT
+            detection: java_shared_lang_user_input
+            scope: cursor
+  - id: java_lang_xml_external_entity_vulnerability_file
+    patterns:
+      - pattern: $<FILE_CLASS> $<FILE> = new $<FILE_CLASS>($<USER_INPUT>$<...>);
+        focus: FILE
+        filters:
+          - variable: FILE_CLASS
+            regex: \A(java\.io\.)?File\z
+          - variable: USER_INPUT
+            detection: java_shared_lang_user_input
+            scope: cursor
+  - id: java_lang_xml_external_entity_vulnerability_url
+    patterns:
+      - pattern: $<URL_CLASS> $<URL> = new $<URL_CLASS>($<USER_INPUT>$<...>);
+        focus: URL
+        filters:
+          - variable: URL_CLASS
+            regex: \A(java\.net\.)?URL\z
+          - variable: USER_INPUT
+            detection: java_shared_lang_user_input
+            scope: cursor
+  - id: java_lang_xml_external_entity_vulnerability_stream_source
+    patterns:
+      - pattern: new StreamSource($<STRING_READER>);
+        filters:
+          - variable: STRING_READER
+            detection: java_lang_xml_external_entity_vulnerability_string_reader
+  - id: java_lang_xml_external_entity_vulnerability_string_reader
+    patterns:
+      - pattern: new $<STRING_READER_CLASS>($<STRING_BUFFER>.toString());
+        filters:
+          - variable: STRING_READER_CLASS
+            regex: \A(java\.lang\.)?StringReader\z
+          - variable: STRING_BUFFER
+            detection: java_lang_xml_external_entity_vulnerability_string_buffer
+  - id: java_lang_xml_external_entity_vulnerability_string_buffer
+    patterns:
+      - pattern: $<STRING_BUFFER_CLASS> $<STRING_BUFFER> = new $<STRING_BUFFER_CLASS>($<USER_INPUT>$<...>);
+        focus: STRING_BUFFER
+        filters:
+          - variable: STRING_BUFFER_CLASS
+            regex: \A(java\.lang\.)?StringBuffer\z
+          - variable: USER_INPUT
+            detection: java_shared_lang_user_input
+            scope: cursor
+  - id: java_lang_xml_external_entity_vulnerability_document_builder
+    patterns:
+      - pattern: $<DOCUMENT_BUILDER>.newDocumentBuilder();
+        filters:
+          - variable: DOCUMENT_BUILDER
+            detection: java_lang_xml_external_entity_vulnerability_document_builder_factory
+  - id: java_lang_xml_external_entity_vulnerability_document_builder_factory
+    patterns:
+      - pattern: $<DOCUMENT_BUILDER_FACTORY>.newInstance();
+        filters:
+          - variable: DOCUMENT_BUILDER_FACTORY
+            regex: \A(javax\.xml\.parsers\.)?DocumentBuilderFactory\z
+  - id: java_lang_xml_external_entity_vulnerability_unmarshaller
+    patterns:
+      - pattern: $<JAXB_INSTANCE>.createUnmarshaller();
+        filters:
+          - variable: JAXB_INSTANCE
+            detection: java_lang_xml_external_entity_vulnerability_jaxb_instance
+  - id: java_lang_xml_external_entity_vulnerability_jaxb_instance
+    patterns:
+      - pattern: $<JAXB>.newInstance();
+        filters:
+          - variable: JAXB
+            regex: \A(javax\.xml\.bind\.)?JAXBContext\z
+languages:
+  - java
+severity: high
+metadata:
+  description: Unsanitized user input in XML External Entity
+  remediation_message: |
+    ## Description
+    Avoid parsing untrusted data as XML. Such data could include URIs that resolve to resources that are outside of the current context, leading to XML External Entity (XXE) injection.
+
+    ## Remediations
+
+    ❌ Do not enable parsing of external entities.
+
+    ## Resources
+    - [OWASP XML External Entity (XXE) prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)
+  cwe_id:
+    - 611
+  id: java_lang_xml_external_entity_vulnerability
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_xml_external_entity_vulnerability

--- a/tests/java/lang/xml_external_entity_vulnerability/test.js
+++ b/tests/java/lang/xml_external_entity_vulnerability/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("xml_external_entity_vulnerability", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/java/lang/xml_external_entity_vulnerability/testdata/main.java
+++ b/tests/java/lang/xml_external_entity_vulnerability/testdata/main.java
@@ -1,0 +1,74 @@
+import javax.xml.XMLConstants;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+
+public class Foo {
+  public Comment unmarshallerBad(HttpServletRequest request, HttpServletResponse response) throws JAXBException {
+    var jc = JAXBContext.newInstance(Comment.class);
+    var commentXml = request.getInputStream();
+
+    var unmarshaller = jc.createUnmarshaller();
+    // bearer:expected java_lang_xml_external_entity_vulnerability
+    return (Comment) unmarshaller.unmarshal(commentXml);
+  }
+
+  public Comment unmarshallerBad2(HttpServletRequest request, HttpServletResponse response) throws JAXBException {
+    var jc = JAXBContext.newInstance(Comment.class);
+    URL url = new URL(request.getParameter("commentURL"));
+
+    var unmarshaller = jc.createUnmarshaller();
+    // bearer:expected java_lang_xml_external_entity_vulnerability
+    return (Comment) unmarshaller.unmarshal(url);
+  }
+
+  public Comment unmarshallerBad3(HttpServletRequest request, HttpServletResponse response) throws JAXBException {
+    JAXBContext jc = JAXBContext.newInstance();
+    Unmarshaller u = jc.createUnmarshaller();
+    StringBuffer xmlStr = new StringBuffer(request.getParameter("commentStr"));
+    // bearer:expected java_lang_xml_external_entity_vulnerability
+    Object o = u.unmarshal(new StreamSource(new StringReader(xmlStr.toString())));
+  }
+
+  public Comment documentBuilderBad(HttpServletRequest request, HttpServletResponse response) throws ParserConfigurationException {
+    InputStream commentFileInputStream = new FileInputStream(request.getParameter("commentFile"));
+
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder builder = factory.newDocumentBuilder();
+
+    // bearer:expected java_lang_xml_external_entity_vulnerability
+    return builder.parse(commentFileInputStream);
+  }
+
+  public User documentBuilderBad2(HttpServletRequest request, HttpServletResponse response) throws ParserConfigurationException {
+    File userFile = new File(request.getParameter("userFile"));
+
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder builder = factory.newDocumentBuilder();
+
+    // bearer:expected java_lang_xml_external_entity_vulnerability
+    return builder.parse(userFile);
+  }
+
+  public User ok(String userFile, String userXML) throws JAXBException, ParserConfigurationException {
+    File userFile = new File(userFile);
+
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    DocumentBuilder builder = factory.newDocumentBuilder();
+
+    User user = builder.parse(userFile);
+
+    var jc = JAXBContext.newInstance(Comment.class);
+    var commentXml = request.getInputStream();
+
+    var unmarshaller = jc.createUnmarshaller();
+    return (Comment) unmarshaller.unmarshal(userXML);
+  }
+}


### PR DESCRIPTION
## Description

Add Java rule for XXE, for `DocumentBuilder.parse` and `JAXBContext` unmarshal method.  

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
