### PR TITLE
fix(js): incorrect CWE for observable timing rule

### DIFF
--- a/rules/javascript/lang/observable_timing.yml
+++ b/rules/javascript/lang/observable_timing.yml
@@ -141,6 +141,6 @@ metadata:
     - [MDN Web Docs on SubtleCrypto API](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto)
 
   cwe_id:
-    - 409
+    - 208
   id: javascript_lang_observable_timing
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_observable_timing


### PR DESCRIPTION
## Description

CWE-208 for timing attacks, not CWE-409 Improper Handling of Highly Compressed Data (Data Amplification)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
