### PR TITLE
feat(java): add observable timing rule

### DIFF
--- a/rules/go/lang/observable_timing.yml
+++ b/rules/go/lang/observable_timing.yml
@@ -8,6 +8,7 @@ patterns:
         regex: /pass(word)?/
 languages:
   - go
+severity: medium
 metadata:
   description: "Observable Timing Discrepancy"
   remediation_message: |

--- a/rules/java/lang/observable_timing.yml
+++ b/rules/java/lang/observable_timing.yml
@@ -1,0 +1,50 @@
+patterns:
+  - pattern: $<_>.equals($<KEY>);
+    filters:
+      - variable: KEY
+        regex: (?i)\A(password)|hash|(api|auth)?.?(token|secret)\z
+  - pattern: $<KEY>.equals($<_>);
+    filters:
+      - variable: KEY
+        regex: (?i)\A(password)|hash|(api|auth)?.?(token|secret)\z
+languages:
+  - java
+severity: medium
+metadata:
+  description: "Observable Timing Discrepancy"
+  remediation_message: |
+    ## Description
+
+    Observable Timing Discrepancy refers to vulnerabilities arising from attackers being able to observe differences in the time it takes to perform certain operations.
+    These discrepancies can lead to the exposure of sensitive information, as attackers can use timing analysis to infer secrets based on the execution time of algorithms, particularly during comparisons of user input against secret values.
+
+    ## Remediations
+
+    ✅ **Implement Constant Time Algorithms**
+
+    Ensure algorithms that process sensitive information, such as password comparisons, execute in constant time to prevent timing attacks.
+
+    ✅ **Use Built-in Security Features**
+
+    Leverage built-in cryptographic libraries that include timing-attack safe functions for comparing secrets.
+
+    ✅ **Minimize Client-Side Checks**
+
+    Avoid sensitive comparisons directly in client-side JavaScript where possible, as the execution environment is more exposed to timing analysis by attackers.
+
+    ❌ **Avoid Direct Comparisons**
+
+    Do not use direct string comparisons for sensitive information that can lead to early function termination based on the first incorrect character.
+
+    ❌ **Do Not Rely on Execution Time for Logic**
+
+    Ensure the application's logic does not change execution paths in a way that could introduce observable timing differences based on user input or secret values.
+
+    ## Resources
+
+    - [CWE-208: Observable Timing Discrepancy](https://cwe.mitre.org/data/definitions/208.html)
+    - [OWASP Guide to Cryptography](https://owasp.org/www-project-cheat-sheets/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
+  cwe_id:
+    - 208
+  id: java_lang_observable_timing
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_observable_timing

--- a/rules/javascript/lang/observable_timing.yml
+++ b/rules/javascript/lang/observable_timing.yml
@@ -104,6 +104,7 @@ auxiliary:
 
 languages:
   - javascript
+severity: medium
 metadata:
   description: "Observable Timing Discrepancy"
   remediation_message: |

--- a/tests/java/lang/observable_timing/test.js
+++ b/tests/java/lang/observable_timing/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("observable_timing", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/java/lang/observable_timing/testdata/main.java
+++ b/tests/java/lang/observable_timing/testdata/main.java
@@ -1,0 +1,13 @@
+public boolean bad(String password) {
+  boolean passwordCorrect = "admin".equals(username)
+    // bearer:expected java_lang_observable_timing
+    && PASSWORD
+        .replace("1234", String.format("%04d", ImageServlet.PINCODE))
+        .equals(password);
+  return passwordCorrect
+}
+
+public boolean ok(String username) {
+  boolean isAdmin = "admin".equals(username);
+  return isAdmin;
+}


### PR DESCRIPTION
## Description

Add Java rule for observable timing

Relates to [#197](https://github.com/Bearer/bearer-rules/issues/197)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
