### PR TITLE
feat(java): add jwt missing signature verification

### DIFF
--- a/rules/java/lang/jwt_verification_bypass.yml
+++ b/rules/java/lang/jwt_verification_bypass.yml
@@ -1,0 +1,41 @@
+patterns:
+  - pattern: |
+      $<JWTS>.parse();
+    filters:
+      - variable: JWTS
+        detection: java_lang_jwt_verification_bypass_jwts
+auxiliary:
+  - id: java_lang_jwt_verification_bypass_jwts
+    patterns:
+      - pattern: $<JWTS>;
+        filters:
+          - variable: JWTS
+            regex: \A(io\.jsonwebtoken\.)?Jwts\z
+languages:
+  - java
+severity: low
+metadata:
+  description: Missing signature verification of JWT
+  remediation_message: |
+    ## Description
+
+    With JSON Web Tokens (JWTs), signature verification allows us to ensure the authenticity and integrity of the token.
+    Not verifying the siguature of JWTs is bad security practice and makes an application vulnerable to token forgery and token replay attacks.
+
+    The `parse()` method does not perform signature verification, and should be avoided in most cases.
+    Instead, use the `parseClaimsJets()` method which does perform signature verification.
+
+    ## Remediations
+
+    ❌ Avoid using `parse()` to inspect JWT payloads because this method does not verify the token's signature
+
+    ✅ Prefer `parseClaimsJws()` because this will verify the JWT signature
+
+    ## References
+
+    - [JWT for Java Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html)
+
+  cwe_id:
+    - 347
+  id: java_lang_jwt_verification_bypass
+  documentation_url: https://docs.bearer.com/reference/rules/java_lang_jwt_verification_bypass

--- a/tests/java/lang/jwt_verification_bypass/test.js
+++ b/tests/java/lang/jwt_verification_bypass/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("jwt_verification_bypass", () => {
+    const testCase = "main.java"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/java/lang/jwt_verification_bypass/testdata/main.java
+++ b/tests/java/lang/jwt_verification_bypass/testdata/main.java
@@ -1,0 +1,13 @@
+// Use bearer:expected java_lang_jwt_verification_bypass to flag expected findings
+
+public static final String JWT_PASSWORD = TextCodec.BASE64.encode("something");
+
+public void bad(String accessToken) {
+  // bearer:expected java_lang_jwt_verification_bypass
+  Jwt jwt = Jwts.parser().setSigningKey(JWT_PASSWORD).parse(accessToken);
+  Claims claims = (Claims) jwt.getBody();
+}
+
+public void good(String accessToken) {
+  Jwt jwt = Jwts.parser().setSigningKey(JWT_PASSWORD).parseClaimsJws(accessToken);
+}


### PR DESCRIPTION
## Description

Add rule to catch use of `parse()` with JWT token as this does not perform signature verification

Relates to #197  

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
