### PR TITLE
fix: linting and missing rule severity

### DIFF
--- a/rules/go/lang/hardcoded_mysql_database_password.yml
+++ b/rules/go/lang/hardcoded_mysql_database_password.yml
@@ -47,3 +47,4 @@ metadata:
     - 259
   id: go_lang_hardcoded_mysql_database_password
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_hardcoded_mysql_database_password
+severity: low

--- a/rules/go/lang/hardcoded_pg_database_password.yml
+++ b/rules/go/lang/hardcoded_pg_database_password.yml
@@ -47,3 +47,4 @@ metadata:
     - 259
   id: go_lang_hardcoded_pg_database_password
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_hardcoded_pg_database_password
+severity: low

--- a/rules/go/lang/observable_timing.yml
+++ b/rules/go/lang/observable_timing.yml
@@ -47,3 +47,4 @@ metadata:
     - 208
   id: go_lang_observable_timing
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_observable_timing
+severity: medium

--- a/rules/go/lang/permissive_regex_validation.yml
+++ b/rules/go/lang/permissive_regex_validation.yml
@@ -53,3 +53,4 @@ metadata:
     - 625
   id: go_lang_permissive_regex_validation
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_permissive_regex_validation
+severity: low

--- a/rules/go/lang/ssl_verification.yml
+++ b/rules/go/lang/ssl_verification.yml
@@ -44,3 +44,4 @@ metadata:
     - 295
   id: go_lang_ssl_verification
   documentation_url: https://docs.bearer.com/reference/rules/go_lang_ssl_verification
+severity: medium

--- a/rules/java/lang/ssl_hostname_verifier.yml
+++ b/rules/java/lang/ssl_hostname_verifier.yml
@@ -223,3 +223,4 @@ metadata:
     - 295
   id: java_lang_ssl_hostname_verifier
   documentation_url: https://docs.bearer.com/reference/rules/java_lang_ssl_hostname_verifier
+severity: medium

--- a/rules/java/third_parties/elasticsearch.yml
+++ b/rules/java/third_parties/elasticsearch.yml
@@ -62,3 +62,4 @@ metadata:
   associated_recipe: Elasticsearch
   id: java_third_parties_elasticsearch
   documentation_url: https://docs.bearer.com/reference/rules/java_third_parties_elasticsearch
+severity: high

--- a/rules/javascript/lang/observable_timing.yml
+++ b/rules/javascript/lang/observable_timing.yml
@@ -144,3 +144,4 @@ metadata:
     - 208
   id: javascript_lang_observable_timing
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_observable_timing
+severity: medium

--- a/scripts/rule_schema_v2.jsonc
+++ b/scripts/rule_schema_v2.jsonc
@@ -111,7 +111,8 @@
       "else": {
         "properties": {
           "metadata": { "$ref": "#/definitions/Metadata" }
-        }
+        },
+        "required": ["severity"]
       },
       "title": "Rule"
     },


### PR DESCRIPTION
## Description
Severity was not linted correctly, this means sometimes severity was missing. Replacements are based on similar rules for now we will review overall severity usage later.

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
