### PR TITLE
ci: enable go third party rule tests

### DIFF
--- a/.github/workflows/canary_integration_tests.yml
+++ b/.github/workflows/canary_integration_tests.yml
@@ -37,9 +37,10 @@ jobs:
             "php/symfony",
             "php/third_parties",
             "python/lang",
-            "go/lang",
-            "go/gosec",
             "go/gorilla",
+            "go/gosec",
+            "go/lang",
+            "go/third_parties",
           ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -46,6 +46,7 @@ jobs:
             "go/lang",
             "go/gosec",
             "go/gorilla",
+            "go/third_parties",
           ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Enables tests for Go third party rules. Requires changes from https://github.com/Bearer/bearer/pull/1546

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
