### PR TITLE
fix(ruby): add missing URI#read case

### DIFF
--- a/rules/ruby/lang/http_url_using_user_input.yml
+++ b/rules/ruby/lang/http_url_using_user_input.yml
@@ -99,11 +99,15 @@ patterns:
       - variable: USER_INPUT
         detection: ruby_shared_common_user_input
         scope: result
-  - pattern: $<URI>.open$<...>
+  - pattern: $<URI>.$<METHOD>$<...>
     filters:
       - variable: URI
         detection: ruby_lang_http_url_using_user_input_uri
         scope: cursor
+      - variable: METHOD
+        values:
+          - open
+          - read
   - pattern: open($<URI>$<...>)$<...>
     filters:
       - variable: URI

--- a/tests/ruby/lang/http_url_using_user_input/testdata/ok_not_unsafe.rb
+++ b/tests/ruby/lang/http_url_using_user_input/testdata/ok_not_unsafe.rb
@@ -64,3 +64,4 @@ uri = URI(x)
 open(uri, "r")
 Kernel.open(uri) {}
 uri.open
+uri.read

--- a/tests/ruby/lang/http_url_using_user_input/testdata/unsafe_open.rb
+++ b/tests/ruby/lang/http_url_using_user_input/testdata/unsafe_open.rb
@@ -8,3 +8,6 @@ Kernel.open(uri) {}
 
 # bearer:expected ruby_lang_http_url_using_user_input
 uri.open
+
+# bearer:expected ruby_lang_http_url_using_user_input
+uri.read


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a pattern for `URI#read` to the Ruby SSRF rule

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
