### PR TITLE
fix(ruby): add missing rails XSS send_data case

### DIFF
--- a/rules/ruby/rails/render_using_user_input.yml
+++ b/rules/ruby/rails/render_using_user_input.yml
@@ -15,6 +15,11 @@ patterns:
       - variable: USER_INPUT
         detection: ruby_shared_common_html_user_input
         scope: result
+  - pattern: send_data($<USER_INPUT>$<...>)
+    filters:
+      - variable: USER_INPUT
+        detection: ruby_shared_common_html_user_input
+        scope: result
 severity: high
 metadata:
   description: "Unsanitized user input in raw HTML strings (XSS)"

--- a/tests/ruby/rails/render_using_user_input/testdata/ok_not_unsafe.rb
+++ b/tests/ruby/rails/render_using_user_input/testdata/ok_not_unsafe.rb
@@ -3,3 +3,5 @@ render inline: "ok"
 
 render html: sanitize(params[:oops])
 render inline: "<h1>#{strip_tags(params[:oops])}</h1>"
+
+send_data "ok", type: content_type

--- a/tests/ruby/rails/render_using_user_input/testdata/unsafe.rb
+++ b/tests/ruby/rails/render_using_user_input/testdata/unsafe.rb
@@ -2,3 +2,6 @@
 render html: params[:oops]
 # bearer:expected ruby_rails_render_using_user_input
 render inline: "<h1>#{params[:oops]}</h1>"
+
+# bearer:expected ruby_rails_render_using_user_input
+send_data params[:oops], type: content_type


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds `send_data` to the Ruby on Rails XSS rule

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
