### PR TITLE
fix(ruby): only consider inline disposition as xss for send_data

### DIFF
--- a/rules/ruby/rails/render_using_user_input.yml
+++ b/rules/ruby/rails/render_using_user_input.yml
@@ -15,11 +15,23 @@ patterns:
       - variable: USER_INPUT
         detection: ruby_shared_common_html_user_input
         scope: result
-  - pattern: send_data($<USER_INPUT>$<...>)
+  - pattern: |
+      send_data($<USER_INPUT>, disposition: $<DISPOSITION>)
     filters:
       - variable: USER_INPUT
         detection: ruby_shared_common_html_user_input
         scope: result
+      - not:
+          variable: DISPOSITION
+          detection: ruby_rails_render_using_user_input_attachment
+          scope: cursor
+auxiliary:
+  - id: ruby_rails_render_using_user_input_attachment
+    patterns:
+      - pattern: $<VALUE>
+        filters:
+          - variable: VALUE
+            string_regex: \Aattachment\z
 severity: high
 metadata:
   description: "Unsanitized user input in raw HTML strings (XSS)"

--- a/tests/ruby/rails/render_using_user_input/testdata/ok_not_unsafe.rb
+++ b/tests/ruby/rails/render_using_user_input/testdata/ok_not_unsafe.rb
@@ -4,4 +4,5 @@ render inline: "ok"
 render html: sanitize(params[:oops])
 render inline: "<h1>#{strip_tags(params[:oops])}</h1>"
 
-send_data "ok", type: content_type
+send_data params[:user_input], type: content_type
+send_data params[:user_input], type: content_type, disposition: "attachment"

--- a/tests/ruby/rails/render_using_user_input/testdata/unsafe.rb
+++ b/tests/ruby/rails/render_using_user_input/testdata/unsafe.rb
@@ -4,4 +4,6 @@ render html: params[:oops]
 render inline: "<h1>#{params[:oops]}</h1>"
 
 # bearer:expected ruby_rails_render_using_user_input
-send_data params[:oops], type: content_type
+send_data params[:user_input], type: content_type, disposition: "inline"
+# bearer:expected ruby_rails_render_using_user_input
+send_data params[:user_input], type: content_type, disposition: unknown


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

In the `ruby_rails_render_using_user_input` rule, only trigger for `send_data` when the disposition is `inline`, or when we are unsure of the disposition.

XSS is limited to the case when data is returned inline to a browser

## Related
- Close #357 
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
