### PR TITLE
fix(go): fix go cookie rules

### DIFF
--- a/rules/go/lang/cookie_missing_http_only.yml
+++ b/rules/go/lang/cookie_missing_http_only.yml
@@ -6,16 +6,13 @@ patterns:
         scope: cursor_strict
       - not:
           variable: COOKIE
-          detection: go_lang_cookie_missing_http_only_true
+          detection: go_lang_cookie_missing_http_only_http_http_only_cookie
           scope: cursor_strict
 auxiliary:
   - id: go_lang_cookie_missing_http_only_cookie_init
     patterns:
       - import $<!>"net/http"
-      - |
-        import (
-          $<!>"net/http"
-        )
+      - import ($<!>"net/http")
   - id: go_lang_cookie_missing_http_only_true
     patterns:
       - "true"
@@ -26,7 +23,7 @@ auxiliary:
           - variable: HTTP
             detection: go_lang_cookie_missing_http_only_cookie_init
             scope: cursor
-  - id: go_lang_cookie_missing_http_only_http_only_true
+  - id: go_lang_cookie_missing_http_only_http_http_only_cookie
     patterns:
       - pattern: "$<_>{ HttpOnly: $<TRUE> }"
         filters:

--- a/rules/go/lang/insecure_cookie.yml
+++ b/rules/go/lang/insecure_cookie.yml
@@ -6,16 +6,13 @@ patterns:
         scope: cursor_strict
       - not:
           variable: COOKIE
-          detection: go_lang_insecure_cookie_true
+          detection: go_lang_insecure_cookie_http_secure_cookie
           scope: cursor_strict
 auxiliary:
   - id: go_lang_insecure_cookie_cookie_init
     patterns:
       - import $<!>"net/http"
-      - |
-        import (
-          $<!>"net/http"
-        )
+      - import ($<!>"net/http")
   - id: go_lang_insecure_cookie_true
     patterns:
       - "true"
@@ -26,7 +23,7 @@ auxiliary:
           - variable: HTTP
             detection: go_lang_insecure_cookie_cookie_init
             scope: cursor
-  - id: go_lang_insecure_cookie_true
+  - id: go_lang_insecure_cookie_http_secure_cookie
     patterns:
       - pattern: "$<_>{ Secure: $<TRUE> }"
         filters:

--- a/tests/go/lang/cookie_missing_http_only/testdata/main.go
+++ b/tests/go/lang/cookie_missing_http_only/testdata/main.go
@@ -50,3 +50,12 @@ func DeleteCookie(w http.ResponseWriter, cookies []string) {
 		http.SetCookie(w, cookie)
 	}
 }
+
+func Ok(w http.ResponseWriter, name, value string) {
+	cookie := http.Cookie{
+		Name:     name,
+		Value:    value,
+		HttpOnly: true,
+	}
+	http.SetCookie(w, &cookie)
+}

--- a/tests/go/lang/insecure_cookie/testdata/main.go
+++ b/tests/go/lang/insecure_cookie/testdata/main.go
@@ -60,3 +60,12 @@ func DeleteCookie(w http.ResponseWriter, cookies []string) {
 		http.SetCookie(w, cookie)
 	}
 }
+
+func Ok(w http.ResponseWriter, name, value string) {
+	cookie := http.Cookie{
+		Name:     name,
+		Value:    value,
+		Secure:   true,
+	}
+	http.SetCookie(w, &cookie)
+}


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Fixes matching of the `true` case in the Go cookie rules. 

Previously these rules were matching secure cases as incorrect rule names were used in the `not` filter

## Related
- Close #351 
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
