### PR TITLE
feat(go): add TLS MinVersion rule

### DIFF
--- a/rules/go/lang/missing_tls_minversion.yml
+++ b/rules/go/lang/missing_tls_minversion.yml
@@ -1,0 +1,54 @@
+patterns:
+  - pattern: $<TLS_CONFIG>
+    filters:
+      - variable: TLS_CONFIG
+        detection: go_lang_missing_tls_minversion_tls_config
+        scope: cursor_strict
+      - not:
+          variable: TLS_CONFIG
+          detection: go_lang_missing_tls_minversion_missing_minversion
+          scope: cursor_strict
+auxiliary:
+  - id: go_lang_missing_tls_minversion_tls_init
+    patterns:
+      - import $<!>"crypto/tls"
+      - import ($<!>"crypto/tls")
+  - id: go_lang_missing_tls_minversion_tls_config
+    patterns:
+      - pattern: $<TLS>.Config{}
+        filters:
+          - variable: TLS
+            detection: go_lang_missing_tls_minversion_tls_init
+            scope: cursor
+  - id: go_lang_missing_tls_minversion_missing_minversion
+    patterns:
+      - |
+        $<_>{ MinVersion: $<_> }
+languages:
+  - go
+severity: warning
+metadata:
+  description: Missing TLS MinVersion
+  remediation_message: |
+    ## Description
+
+    Older versions of TLS (Transport Layer Security) have been deprecated because of known security issues.
+    It is therefore best security practice to always configure the minimum TLS version accepted by the server.
+
+    ## Remediations
+
+    ✅ Set `MinVersion` in the `tls.Config` struct to `tls.VersionTLS13` or, for legacy applications, to the highest possible supported version of TLS.
+
+    ```
+      {
+        MinVersion: tls.VersionTLS13
+      }
+    ```
+
+    ## References
+
+    - [OWASP TLS Cipher String Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/TLS_Cipher_String_Cheat_Sheet.html)
+  cwe_id:
+    - 327
+  id: go_lang_missing_tls_minversion
+  documentation_url: https://docs.bearer.com/reference/rules/go_lang_missing_tls_minversion

--- a/tests/go/lang/missing_tls_minversion/test.js
+++ b/tests/go/lang/missing_tls_minversion/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("missing_tls_minversion", () => {
+    const testCase = "main.go"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/go/lang/missing_tls_minversion/testdata/main.go
+++ b/tests/go/lang/missing_tls_minversion/testdata/main.go
@@ -1,0 +1,54 @@
+package go_lang_missing_tls_minversion
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+// zeroSource is an io.Reader that returns an unlimited number of zero bytes.
+type zeroSource struct{}
+
+func (zeroSource) Read(b []byte) (n int, err error) {
+	for i := range b {
+		b[i] = 0
+	}
+
+	return len(b), nil
+}
+
+func bad() *tls.Config {
+	// bearer:expected go_lang_missing_tls_minversion
+	return &tls.Config{}
+}
+
+func bad2() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			// bearer:expected go_lang_missing_tls_minversion
+			TLSClientConfig: &tls.Config{
+				Certificates: []tls.Certificate{},
+			},
+		},
+	}
+}
+
+func good() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionSSL30,
+			},
+		},
+	}
+}
+
+func good2() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion:         tls.VersionTLS10,
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Description

Add Golang rule to catch TLS configuration without MinVersion defined

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
