### PR TITLE
fix(go): QueryContext can take three args

### DIFF
--- a/rules/go/gosec/sql/concat_sqli.yml
+++ b/rules/go/gosec/sql/concat_sqli.yml
@@ -26,7 +26,7 @@ patterns:
             detection: go_gosec_sql_concat_sqli_sql_db_begin
             scope: cursor
           - variable: DB
-            regex: (?i).*(db|database)
+            regex: (?i).*(db|database|client)
   - pattern: |
       $<DB>.$<METHOD>($<_>, $<INPUT>)
     filters:
@@ -48,7 +48,28 @@ patterns:
             detection: go_gosec_sql_concat_sqli_sql_db_begin
             scope: cursor
           - variable: DB
-            string_regex: (?i).*(db|database)
+            regex: (?i).*(db|database|client)
+  - pattern: |
+      $<DB>.$<METHOD>($<_>, $<_>, $<INPUT>)
+    filters:
+      - variable: METHOD
+        values:
+          - QueryContext
+          - ExecContext
+      - variable: INPUT
+        detection: go_gosec_sql_concat_sqli_unsanitized_input
+      - not:
+          variable: INPUT
+          detection: go_gosec_sql_concat_sqli_input_sprintf_sanitizer
+      - either:
+          - variable: DB
+            detection: go_gosec_sql_concat_sqli_sql_open
+            scope: cursor
+          - variable: DB
+            detection: go_gosec_sql_concat_sqli_sql_db_begin
+            scope: cursor
+          - variable: DB
+            regex: (?i).*(db|database|client)
 auxiliary:
   - id: go_gosec_sql_concat_sqli_input_sprintf_sanitizer
     patterns:

--- a/tests/go/gosec/sql/concat_sqli/test.js
+++ b/tests/go/gosec/sql/concat_sqli/test.js
@@ -7,7 +7,16 @@ const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
 describe(ruleId, () => {
   const invoke = createNewInvoker(ruleId, ruleFile, testBase)
 
-  
+    test("query_context", () => {
+      const testCase = "query_context.go"
+
+      const results = invoke(testCase)
+
+      expect(results.Missing).toEqual([])
+      expect(results.Extra).toEqual([])
+    })
+
+
     test("function", () => {
       const testCase = "function.go"
 

--- a/tests/go/gosec/sql/concat_sqli/testdata/query_context.go
+++ b/tests/go/gosec/sql/concat_sqli/testdata/query_context.go
@@ -1,0 +1,13 @@
+// Format string without proper quoting
+package main
+
+func (s PostgreSQLBackend) bad(prefix string) {
+	ctx := ""
+	list_query := "SOME SQL WITH VAR ?"
+	// bearer:expected go_gosec_sql_concat_sqli
+	rows, err := s.client.QueryContext(ctx, list_query, "/"+prefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+}


### PR DESCRIPTION
## Description

`QueryContext` and `ExecContext` can take three args, and our pattern was not accounting for this
Also add `client` as fallback for database instance

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
