### PR TITLE
fix(go): include 0oXXX for bad file permission

### DIFF
--- a/rules/go/gosec/filesystem/poor_write_permissions.yml
+++ b/rules/go/gosec/filesystem/poor_write_permissions.yml
@@ -16,7 +16,7 @@ auxiliary:
               - variable: MASK
                 regex: \A0\d[1-7]
               - variable: MASK
-                regex: \A0\d\d[1-7]
+                regex: \A0(o)?\d\d[1-7]
 languages:
   - go
 metadata:

--- a/tests/go/gosec/filesystem/poor_write_permissions/testdata/main.go
+++ b/tests/go/gosec/filesystem/poor_write_permissions/testdata/main.go
@@ -16,11 +16,14 @@ func check(e error) {
 func mainwriteperms() {
 
 	d1 := []byte("hello\ngo\n")
-// bearer:expected go_gosec_filesystem_poor_write_permissions
+	// bearer:expected go_gosec_filesystem_poor_write_permissions
 	err := ioutil.WriteFile("/tmp/dat1", d1, 0744)
 	check(err)
 
 	allowed := ioutil.WriteFile("/tmp/dat1", d1, 0600)
+
+	// bearer:expected go_gosec_filesystem_poor_write_permissions
+	err = ioutil.WriteFile("/tmp/dat1", d1, 0o755)
 	check(allowed)
 
 	f, err := os.Create("/tmp/dat2")


### PR DESCRIPTION
## Description

Extend current golang file permission rule so that it catches cases like `0o755` 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
