### PR TITLE
fix(golang): fixes following battletesting

### DIFF
--- a/rules/go/gosec/injection/subproc_injection.yml
+++ b/rules/go/gosec/injection/subproc_injection.yml
@@ -2,25 +2,29 @@ imports:
   - go_shared_lang_dynamic_input_combined
 patterns:
   - pattern: |
-      exec.CommandContext($<CTX>, $<INPUT>$<...>)
+      exec.CommandContext($<_>, $<...>$<INPUT>$<...>)
     filters:
       - variable: INPUT
         detection: go_shared_lang_dynamic_input_combined
+        scope: result
   - pattern: |
       exec.Command($<...>$<INPUT>$<...>)
     filters:
       - variable: INPUT
         detection: go_shared_lang_dynamic_input_combined
+        scope: result
   - pattern: |
       syscall.ForkExec($<INPUT>$<...>)
     filters:
       - variable: INPUT
         detection: go_shared_lang_dynamic_input_combined
+        scope: result
   - pattern: |
       syscall.StartProcess($<INPUT>$<...>)
     filters:
       - variable: INPUT
         detection: go_shared_lang_dynamic_input_combined
+        scope: result
 languages:
   - go
 severity: high

--- a/rules/go/shared/lang/dynamic_input.yml
+++ b/rules/go/shared/lang/dynamic_input.yml
@@ -7,6 +7,12 @@ patterns:
       - variable: INPUT
         detection: go_shared_lang_dynamic_input_input
         scope: cursor_strict
+  # array access
+  - pattern: $<INPUT>[$<_>]
+    filters:
+      - variable: INPUT
+        detection: go_shared_lang_dynamic_input
+        scope: cursor
   - pattern: $<READER>.ReadString()
     filters:
       - variable: READER

--- a/rules/go/shared/lang/instance.yml
+++ b/rules/go/shared/lang/instance.yml
@@ -17,6 +17,11 @@ patterns:
       - variable: INSTANCE
         detection: go_shared_lang_instance
         scope: cursor
+        imports:
+          - variable: PACKAGE
+            as: PACKAGE
+          - variable: TYPE
+            as: TYPE
 metadata:
   description: "Go instance."
   id: go_shared_lang_instance

--- a/tests/go/gosec/filesystem/filereadtaint/testdata/main.go
+++ b/tests/go/gosec/filesystem/filereadtaint/testdata/main.go
@@ -10,9 +10,15 @@ import (
 	"path/filepath"
 )
 
+func bad(args []string) {
+	filepath := args[0]
+	// bearer:expected go_gosec_filesystem_filereadtaint
+	os.Open(filepath)
+}
+
 func mainenvreadfile() {
 	f := os.Getenv("tainted_file")
-// bearer:expected go_gosec_filesystem_filereadtaint
+	// bearer:expected go_gosec_filesystem_filereadtaint
 	body, err := ioutil.ReadFile(f)
 	if err != nil {
 		log.Printf("Error: %v\n", err)
@@ -24,7 +30,7 @@ func mainenvreadfile() {
 func mainqueryopen() {
 	http.HandleFunc("/bar", func(w http.ResponseWriter, r *http.Request) {
 		title := r.URL.Query().Get("title")
-// bearer:expected go_gosec_filesystem_filereadtaint
+		// bearer:expected go_gosec_filesystem_filereadtaint
 		f, err := os.Open(title)
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)
@@ -41,7 +47,7 @@ func mainqueryopen() {
 func mainqueryopenfile() {
 	http.HandleFunc("/bar", func(w http.ResponseWriter, r *http.Request) {
 		title := r.URL.Query().Get("title")
-// bearer:expected go_gosec_filesystem_filereadtaint
+		// bearer:expected go_gosec_filesystem_filereadtaint
 		f, err := os.OpenFile(title, os.O_RDWR|os.O_CREATE, 0755)
 		if err != nil {
 			fmt.Printf("Error: %v\n", err)
@@ -57,7 +63,7 @@ func mainqueryopenfile() {
 
 func mainenvreadfileappend() {
 	f2 := os.Getenv("tainted_file2")
-// bearer:expected go_gosec_filesystem_filereadtaint
+	// bearer:expected go_gosec_filesystem_filereadtaint
 	body, err := ioutil.ReadFile("/tmp/" + f2)
 	if err != nil {
 		log.Printf("Error: %v\n", err)
@@ -70,7 +76,7 @@ func mainstdinopenjoin() {
 	fmt.Print("Please enter file to read: ")
 	file, _ := reader.ReadString('\n')
 	file = file[:len(file)-1]
-// bearer:expected go_gosec_filesystem_filereadtaint
+	// bearer:expected go_gosec_filesystem_filereadtaint
 	f, err := os.Open(filepath.Join("/tmp/service/", file))
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
@@ -86,7 +92,7 @@ func mainenvreadfilejointwice() {
 	dir := os.Getenv("server_root")
 	f3 := os.Getenv("tainted_file3")
 	// edge case where both a binary expression and file Join are used.
-// bearer:expected go_gosec_filesystem_filereadtaint
+	// bearer:expected go_gosec_filesystem_filereadtaint
 	body, err := ioutil.ReadFile(filepath.Join("/var/"+dir, f3))
 	if err != nil {
 		log.Printf("Error: %v\n", err)


### PR DESCRIPTION
## Description

* Add pattern to dynamic input rule to match on array (e.g. `insecure[0]`)
* Add scoping to subproc rule
* Fix missing var issue with lang instance rule

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
