### PR TITLE
fix: subproc injection rule

### DIFF
--- a/rules/go/gosec/injection/subproc_injection.yml
+++ b/rules/go/gosec/injection/subproc_injection.yml
@@ -6,25 +6,21 @@ patterns:
     filters:
       - variable: INPUT
         detection: go_shared_lang_dynamic_input_combined
-        scope: result
   - pattern: |
       exec.Command($<...>$<INPUT>$<...>)
     filters:
       - variable: INPUT
         detection: go_shared_lang_dynamic_input_combined
-        scope: result
   - pattern: |
       syscall.ForkExec($<INPUT>$<...>)
     filters:
       - variable: INPUT
         detection: go_shared_lang_dynamic_input_combined
-        scope: result
   - pattern: |
       syscall.StartProcess($<INPUT>$<...>)
     filters:
       - variable: INPUT
         detection: go_shared_lang_dynamic_input_combined
-        scope: result
 languages:
   - go
 severity: high


### PR DESCRIPTION
## Description

The scoping added here https://github.com/Bearer/bearer-rules/pull/365 causes a regression and we miss cases like `userName.Value` (see added test case)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
