### PR TITLE
fix(golang): CWE for compression bomb rule

### DIFF
--- a/rules/go/gosec/filesystem/decompression_bomb.yml
+++ b/rules/go/gosec/filesystem/decompression_bomb.yml
@@ -114,7 +114,7 @@ metadata:
     ```
 
   cwe_id:
-    - 327
+    - 409
   id: go_gosec_filesystem_decompression_bomb
   documentation_url: https://docs.bearer.com/reference/rules/go_gosec_filesystem_decompression_bomb
 severity: low


### PR DESCRIPTION
## Description

Rule incorrectly labelled as CWE 327 when really it is [CWE 409 "Improper Handling of Highly Compressed Data (Data Amplification)"](https://cwe.mitre.org/data/definitions/409.html)

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
