### PR TITLE
fix: clarify permissive regexp rules

### DIFF
--- a/rules/go/lang/permissive_regex_validation.yml
+++ b/rules/go/lang/permissive_regex_validation.yml
@@ -29,6 +29,9 @@ metadata:
     Validations using regular expressions should use the start of text (\A) and
     end of text (\z or \Z) boundaries.
 
+    Note, it is best security practice to prefer the boundary expressions \A and \z or \Z
+    over ^ and $, because ^ and $ operate as line-based boundaries when multiline mode is enabled.
+
     ## Remediations
 
     ❌ Avoid matching without start and end boundaries:
@@ -40,7 +43,7 @@ metadata:
     ❌ Avoid using line-based boundaries:
 
     ```go
-    regexp.MustCompile("^foo$"}
+    regexp.MustCompile("^foo$")
     ```
 
     ✅ Use whole-text boundaries:

--- a/rules/php/symfony/permissive_regex_validation.yml
+++ b/rules/php/symfony/permissive_regex_validation.yml
@@ -57,6 +57,9 @@ metadata:
     Validations using regular expressions should use the start of text (\A) and
     end of text (\z or \Z) boundaries.
 
+    Note, it is best security practice to prefer the boundary expressions \A and \z or \Z
+    over ^ and $, because ^ and $ operate as line-based boundaries when multiline mode is enabled.
+
     ## Remediations
 
     ❌ Avoid matching without start and end boundaries:


### PR DESCRIPTION
## Description

Add clarification to the permissive regexp rules about why the boundary expressions `\A` and `\z`or `\Z` are recommended over `^` and `$`. 

Note, we do not add a clarification to the Rails permissive regexp rule, since for Ruby multiline mode is the default. 

Closes #366 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
