### PR TITLE
fix: typo in PHP rule description

### DIFF
--- a/rules/php/lang/http_url_using_sensitive_data.yml
+++ b/rules/php/lang/http_url_using_sensitive_data.yml
@@ -489,7 +489,6 @@ metadata:
     $curl = curl_init("https://example.com/users?$query");
     ```
 
-    <!--
     ## Resources
     - [OWASP information exposure through URL query strings](https://owasp.org/www-community/vulnerabilities/Information_exposure_through_query_strings_in_url)
   cwe_id:


### PR DESCRIPTION
## Description

Remove a rogue `<!--` in the remediation message for `php_lang_http_url_using_sensitive_data`

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist

- [ ] My rule has adequate metadata to explain its use.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
