### PR TITLE
feat: expand SQLi rules for all GA languages

### DIFF
--- a/rules/javascript/lang/sql_injection.yml
+++ b/rules/javascript/lang/sql_injection.yml
@@ -1,5 +1,5 @@
 imports:
-  - javascript_shared_common_user_input
+  - javascript_shared_common_external_input
 patterns:
   - pattern: |
       $<KNEX_CLIENT>.$<METHOD>($<...>$<USER_INPUT>$<...>)
@@ -73,10 +73,10 @@ auxiliary:
   - id: javascript_lang_sql_injection_user_input
     sanitizer: javascript_lang_sql_injection_sanitizer
     patterns:
-      - pattern: $<UNSANITIZED_USER_INPUT>
+      - pattern: $<UNSANITIZED_INPUT>
         filters:
-          - variable: UNSANITIZED_USER_INPUT
-            detection: javascript_shared_common_user_input
+          - variable: UNSANITIZED_INPUT
+            detection: javascript_shared_common_external_input
             scope: cursor
   - id: javascript_lang_sql_injection_pg_client
     patterns:
@@ -109,18 +109,20 @@ auxiliary:
   - id: javascript_lang_sql_injection_sanitizer
     patterns:
       - pattern: $<_>.hash($<!>$<_>)
+      - |
+        { replacements: [$<...>$<!>$<_>$<...>] }
 languages:
   - javascript
 severity: critical
 metadata:
-  description: "Unsanitized user input in SQL query"
+  description: Unsanitized input in SQL query
   remediation_message: |
     ## Description
-    Including unsanitized data, such as user input or request data, in raw SQL queries makes your application vulnerable to SQL injection attacks.
+    Including unsanitized data, such as user input or request data, or externally influenced data passed to a function, in raw SQL queries makes your application vulnerable to SQL injection attacks.
 
     ## Remediations
 
-    ❌ Avoid raw queries, especially those that contain unsanitized user input
+    ❌ Avoid raw queries, especially those that contain unsanitized input
 
     ```javascript
       var sqlite = new Sequelize("sqlite::memory:");
@@ -138,7 +140,7 @@ metadata:
       }
     ```
 
-    ✅ Use prepared (or parameterized) statements when querying
+    ✅ Always use prepared (or parameterized) statements when querying
 
     Sequelize example -
     ```javascript

--- a/rules/javascript/shared/common/external_input.yml
+++ b/rules/javascript/shared/common/external_input.yml
@@ -1,0 +1,20 @@
+type: shared
+imports:
+  - javascript_shared_common_user_input
+  - javascript_shared_common_dynamic_input
+languages:
+  - javascript
+patterns:
+  - pattern: $<USER_INPUT>
+    filters:
+      - variable: USER_INPUT
+        detection: javascript_shared_common_user_input
+        scope: cursor
+  - pattern: $<DYNAMIC_INPUT>
+    filters:
+      - variable: DYNAMIC_INPUT
+        detection: javascript_shared_common_dynamic_input
+        scope: cursor
+metadata:
+  description: Javascript externally influenced (user or dynamic) input.
+  id: javascript_shared_common_external_input

--- a/rules/php/lang/sql_injection.yml
+++ b/rules/php/lang/sql_injection.yml
@@ -1,7 +1,7 @@
 imports:
-  - php_shared_lang_user_input
+  - php_shared_lang_external_input
 patterns:
-  - pattern: $<ODBC_METHOD>($<_>, $<UNSANITIZED_USER_INPUT>)
+  - pattern: $<ODBC_METHOD>($<_>, $<UNSANITIZED_INPUT>)
     filters:
       - variable: ODBC_METHOD
         values:
@@ -9,21 +9,21 @@ patterns:
           - odbc_exec
           - mssql_query
           - mysqli_query
-      - variable: UNSANITIZED_USER_INPUT
-        detection: php_lang_sql_injection_user_input_unsanitized
+      - variable: UNSANITIZED_INPUT
+        detection: php_lang_sql_injection_external_input_unsanitized
         scope: result
 auxiliary:
-  - id: php_lang_sql_injection_user_input_unsanitized
-    sanitizer: php_lang_sql_injection_user_input_sanitizer
+  - id: php_lang_sql_injection_external_input_unsanitized
+    sanitizer: php_lang_sql_injection_external_input_sanitizer
     patterns:
-      - pattern: $<USER_INPUT>;
+      - pattern: $<INPUT>;
         filters:
-          - variable: USER_INPUT
-            detection: php_shared_lang_user_input
+          - variable: INPUT
+            detection: php_shared_lang_external_input
             scope: cursor
-  - id: php_lang_sql_injection_user_input_sanitizer
+  - id: php_lang_sql_injection_external_input_sanitizer
     patterns:
-      - pattern: $<ESCAPE_METHOD>($<_>, $<!>$<USER_INPUT>)
+      - pattern: $<ESCAPE_METHOD>($<_>, $<!>$<INPUT>)
         filters:
           - variable: ESCAPE_METHOD
             values:
@@ -35,10 +35,10 @@ languages:
   - php
 severity: critical
 metadata:
-  description: "Unsanitized user input in SQL query"
+  description: Unsanitized input in SQL query
   remediation_message: |
     ## Description
-    Including unsanitized data, such as user input or request data, in raw SQL queries makes your application vulnerable to SQL injection attacks.
+    Including unsanitized data, such as user input or request data, or externally influenced data passed to a function, in raw SQL queries makes your application vulnerable to SQL injection attacks.
 
     ## Remediations
 

--- a/rules/php/shared/lang/dynamic_input.yml
+++ b/rules/php/shared/lang/dynamic_input.yml
@@ -1,0 +1,16 @@
+type: shared
+languages:
+  - php
+imports:
+  - php_shared_lang_user_input_sanitizer
+sanitizer: php_shared_lang_user_input_sanitizer
+patterns:
+  - function $<_>($<...>$<!>$<_>$<...>) {}
+  - function($<...>$<!>$<_>$<...>) {}
+  - pattern: |
+      class $<_>$<...>{
+        function $<...>$<NAME>($<...>$<!>$<_>$<...>) {}
+      }
+metadata:
+  description: PHP dynamic input.
+  id: php_shared_lang_dynamic_input

--- a/rules/php/shared/lang/external_input.yml
+++ b/rules/php/shared/lang/external_input.yml
@@ -1,0 +1,20 @@
+imports:
+  - php_shared_lang_user_input
+  - php_shared_lang_dynamic_input
+type: shared
+languages:
+  - php
+patterns:
+  - pattern: $<INPUT>;
+    filters:
+      - variable: INPUT
+        detection: php_shared_lang_user_input
+        scope: cursor_strict
+  - pattern: $<INPUT>;
+    filters:
+      - variable: INPUT
+        detection: php_shared_lang_dynamic_input
+        scope: cursor_strict
+metadata:
+  description: PHP externally influenced (user or dynamic) input.
+  id: php_shared_lang_external_input

--- a/rules/php/symfony/sql_injection.yml
+++ b/rules/php/symfony/sql_injection.yml
@@ -1,7 +1,7 @@
 imports:
-  - php_shared_lang_user_input
+  - php_shared_lang_external_input
 patterns:
-  - pattern: $<_>->$<METHOD>($<UNSANITIZED_USER_INPUT>)
+  - pattern: $<_>->$<METHOD>($<UNSANITIZED_INPUT>)
     filters:
       - variable: METHOD
         values:
@@ -24,53 +24,39 @@ patterns:
           - orHaving
           - orderBy
           - addOrderBy
-      - variable: UNSANITIZED_USER_INPUT
-        detection: php_symfony_sql_injection_user_input_unsanitized
+      - variable: UNSANITIZED_INPUT
+        detection: php_symfony_sql_injection_input_unsanitized
         scope: result
-  - pattern: $<_>->$<METHOD>($<UNSANITIZED_USER_INPUT>)
+  - pattern: $<_>->$<METHOD>($<UNSANITIZED_INPUT>)
     filters:
       - variable: METHOD
         values:
           - prepare
           - createQuery
       - either:
-          - variable: UNSANITIZED_USER_INPUT
-            detection: php_symfony_sql_injection_user_input_unsanitized
+          - variable: UNSANITIZED_INPUT
+            detection: php_symfony_sql_injection_input_unsanitized
             scope: result
-          # - variable: UNSANITIZED_USER_INPUT
-          #   detection: php_symfony_sql_injection_unsanitized_method_argument
-          #   scope: result
 auxiliary:
-  # This will trigger a lot of FPs
-  # We should probably have a separate rule with a lower confidence level
-  # - id: php_symfony_sql_injection_unsanitized_method_argument
-  #   sanitizer: php_symfony_sql_injection_user_input_sanitizer
-  #   patterns:
-  #     - function $<_>($<...>$<!>$<_>$<...>) {}
-  #     - function($<...>$<!>$<_>$<...>) {}
-  #     - pattern: |
-  #         class $<_>$<...>{
-  #           function $<...>$<NAME>($<...>$<!>$<_>$<...>) {}
-  #         }
-  - id: php_symfony_sql_injection_user_input_unsanitized
-    sanitizer: php_symfony_sql_injection_user_input_sanitizer
+  - id: php_symfony_sql_injection_input_unsanitized
+    sanitizer: php_symfony_sql_injection_input_sanitizer
     patterns:
-      - pattern: $<USER_INPUT>;
+      - pattern: $<EXTERNAL_INPUT>;
         filters:
-          - variable: USER_INPUT
-            detection: php_shared_lang_user_input
+          - variable: EXTERNAL_INPUT
+            detection: php_shared_lang_external_input
             scope: cursor
-  - id: php_symfony_sql_injection_user_input_sanitizer
+  - id: php_symfony_sql_injection_input_sanitizer
     patterns:
       - pattern: $<_>->quote($<!>$<_>)
 languages:
   - php
 severity: critical
 metadata:
-  description: "Unsanitized user input in SQL query"
+  description: Unsanitized input in SQL query
   remediation_message: |
     ## Description
-    Including unsanitized data, such as user input or request data, in raw SQL queries makes your application vulnerable to SQL injection attacks.
+    Including unsanitized data, such as user input or request data, or externally influenced data passed to a function, in raw SQL queries makes your application vulnerable to SQL injection attacks.
 
     ## Remediations
 

--- a/rules/ruby/rails/sql_injection.yml
+++ b/rules/ruby/rails/sql_injection.yml
@@ -1,5 +1,5 @@
 imports:
-  - ruby_shared_common_user_input
+  - ruby_shared_common_external_input
 patterns:
   - pattern: $<_>.$<METHOD>($<...>$<USER_INPUT>$<...>)
     filters:
@@ -7,7 +7,7 @@ patterns:
         detection: ruby_rails_sql_injection_regular_method
         scope: cursor
       - variable: USER_INPUT
-        detection: ruby_rails_sql_injection_user_input
+        detection: ruby_rails_sql_injection_external_input
         scope: result
   - pattern: $<METHOD>($<USER_INPUT>$<...>)
     filters:
@@ -15,7 +15,7 @@ patterns:
         detection: ruby_rails_sql_injection_regular_method
         scope: cursor
       - variable: USER_INPUT
-        detection: ruby_rails_sql_injection_user_input
+        detection: ruby_rails_sql_injection_external_input
         scope: result
   - pattern: ActiveRecord::Base.connection.$<CONN_METHOD>($<USER_INPUT>$<...>)
     filters:
@@ -23,7 +23,7 @@ patterns:
         detection: ruby_rails_sql_injection_connection_method
         scope: cursor
       - variable: USER_INPUT
-        detection: ruby_rails_sql_injection_user_input
+        detection: ruby_rails_sql_injection_external_input
         scope: result
   - pattern: connection.$<CONN_METHOD>($<USER_INPUT>$<...>)
     filters:
@@ -31,7 +31,7 @@ patterns:
         detection: ruby_rails_sql_injection_connection_method
         scope: cursor
       - variable: USER_INPUT
-        detection: ruby_rails_sql_injection_user_input
+        detection: ruby_rails_sql_injection_external_input
         scope: result
   - pattern: $<_>.$<SPECIAL_METHOD>($<USER_INPUT>$<...>)
     filters:
@@ -39,7 +39,7 @@ patterns:
         detection: ruby_rails_sql_injection_special_arg_method
         scope: cursor
       - variable: USER_INPUT
-        detection: ruby_rails_sql_injection_user_input
+        detection: ruby_rails_sql_injection_external_input
         scope: result
       - not:
           variable: USER_INPUT
@@ -50,7 +50,7 @@ patterns:
         detection: ruby_rails_sql_injection_special_arg_method
         scope: cursor
       - variable: USER_INPUT
-        detection: ruby_rails_sql_injection_user_input
+        detection: ruby_rails_sql_injection_external_input
         scope: result
       - not:
           variable: USER_INPUT
@@ -107,13 +107,13 @@ auxiliary:
               - delete_by
               - destroy_by
               - update_all
-  - id: ruby_rails_sql_injection_user_input
+  - id: ruby_rails_sql_injection_external_input
     sanitizer: ruby_rails_sql_injection_sanitized
     patterns:
-      - pattern: $<COMMON_USER_INPUT>
+      - pattern: $<COMMON_INPUT>
         filters:
-          - variable: COMMON_USER_INPUT
-            detection: ruby_shared_common_user_input
+          - variable: COMMON_INPUT
+            detection: ruby_shared_common_external_input
             scope: cursor
   - id: ruby_rails_sql_injection_safe_special_arg
     patterns:

--- a/rules/ruby/shared/common/dynamic_input.yml
+++ b/rules/ruby/shared/common/dynamic_input.yml
@@ -1,0 +1,12 @@
+type: shared
+languages:
+  - ruby
+patterns:
+  - |
+    class $<_>
+      def $<METHOD_NAME>($<...>$<!>$<_>$<...>)
+      end
+    end
+metadata:
+  description: Ruby dynamic input.
+  id: ruby_shared_common_dynamic_input

--- a/rules/ruby/shared/common/external_input.yml
+++ b/rules/ruby/shared/common/external_input.yml
@@ -1,0 +1,20 @@
+imports:
+  - ruby_shared_common_user_input
+  - ruby_shared_common_dynamic_input
+type: shared
+languages:
+  - ruby
+patterns:
+  - pattern: $<USER_INPUT>
+    filters:
+      - variable: USER_INPUT
+        detection: ruby_shared_common_user_input
+        scope: cursor_strict
+  - pattern: $<DYNAMIC_INPUT>
+    filters:
+      - variable: DYNAMIC_INPUT
+        detection: ruby_shared_common_dynamic_input
+        scope: cursor_strict
+metadata:
+  description: Ruby externally influenced (user or dynamic) input.
+  id: ruby_shared_common_external_input

--- a/tests/javascript/lang/sql_injection/testdata/mysql2_sql_injection.js
+++ b/tests/javascript/lang/sql_injection/testdata/mysql2_sql_injection.js
@@ -2,6 +2,7 @@ const connection = mysql.createConnection({});
 const asyncConn = await mysql.createConnection({});
 
 module.exports.asyncFooBar = async function (req, res) {
+	// bearer:expected javascript_lang_sql_injection
 	await asyncConn.execute(
 		"SELECT * FROM `admin_users` WHERE ID = " + req.admin.id
 	);

--- a/tests/javascript/lang/sql_injection/testdata/ok_no_sql_injection.js
+++ b/tests/javascript/lang/sql_injection/testdata/ok_no_sql_injection.js
@@ -6,7 +6,7 @@ const client = new Client({
 
 const connection = mysql.createConnection({});
 
-module.exports.fooBar = function(req, _res) {
+module.exports.fooBar = function(req, _res, name) {
   var sqlite = new Sequelize('sqlite::memory:')
   var customerQuery = "SELECT * FROM customers WHERE status = ACTIVE"
   sqlite.query(customerQuery)
@@ -14,4 +14,5 @@ module.exports.fooBar = function(req, _res) {
   client.query('SELECT * FROM users WHERE user.name = ' + getUser().name)
 
   connection.query("SELECT * FROM `user` WHERE name = " + currentUser().name);
+  connection.query("SELECT * FROM `user` WHERE name = ?", { replacements: [name] });
 }

--- a/tests/javascript/lang/sql_injection/testdata/pg_sql_injection.js
+++ b/tests/javascript/lang/sql_injection/testdata/pg_sql_injection.js
@@ -12,3 +12,12 @@ module.exports.fooBar = function (req, _res) {
 
 	return user;
 };
+
+module.exports.bad = function (name) {
+		// bearer:expected javascript_lang_sql_injection
+		var user = client.query(
+			"SELECT * FROM users WHERE user.name = " + name
+		);
+
+		return user;
+	};

--- a/tests/javascript/lang/sql_injection/testdata/sequelize_sql_injection.js
+++ b/tests/javascript/lang/sql_injection/testdata/sequelize_sql_injection.js
@@ -7,3 +7,11 @@ module.exports.fooBar = function (req, _res) {
 // bearer:expected javascript_lang_sql_injection
 	sqlite.query(customerQuery);
 };
+
+module.exports.bad = function (status) {
+	var sqlite = new Sequelize("sqlite::memory:");
+	var customerQuery =
+		"SELECT * FROM customers WHERE status = " + status;
+	// bearer:expected javascript_lang_sql_injection
+	sqlite.query(customerQuery);
+};

--- a/tests/php/lang/sql_injection/testdata/injection.php
+++ b/tests/php/lang/sql_injection/testdata/injection.php
@@ -20,4 +20,12 @@ $query  = "SELECT id, name FROM products ORDER BY name LIMIT 20 $oops;";
 # bearer:expected php_lang_sql_injection
 $result = mysqli_query($conn, $query);
 
+class Foo {
+  public function bad($name) {
+    $query  = "SELECT id, name FROM products WHERE name = $name;";
+    # bearer:expected php_lang_sql_injection
+    $result = mssql_query($conn, $query);
+  }
+}
+
 ?>

--- a/tests/php/lang/sql_injection/testdata/safe.php
+++ b/tests/php/lang/sql_injection/testdata/safe.php
@@ -11,4 +11,13 @@ $ok = mysqli_real_escape_string($conn, $_GET['ok']);
 $query  = "SELECT id, name FROM products ORDER BY name LIMIT 20 $ok;";
 $result = pg_query($conn, $query);
 
+class Foo {
+  public function ok($name) {
+    // The SQL is prepared with a placeholder
+    $stmt = $pdo->prepare("SELECT * FROM products WHERE name {$placeholderName}");
+    // The value is provided with LIKE wildcards
+    $stmt->execute(["%{$name}%"]);
+  }
+}
+
 ?>

--- a/tests/php/symfony/sql_injection/testdata/injection.php
+++ b/tests/php/symfony/sql_injection/testdata/injection.php
@@ -23,4 +23,14 @@ class FooRepository extends ServiceEntityRepository
         $data = $query->getResult();
         return $data;
     }
+
+    public function oops3(string $bar): array
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        # bearer:expected php_symfony_sql_injection
+        $query = $conn->createQuery("SELECT * FROM foo WHERE bar = '" . $bar . "'");
+        $data = $query->getResult();
+        return $data;
+    }
 }

--- a/tests/ruby/rails/sql_injection/testdata/injected_params.rb
+++ b/tests/ruby/rails/sql_injection/testdata/injected_params.rb
@@ -18,3 +18,10 @@ ActiveRecord::Base.connection.exec_query("SELECT #{params[:oops]}")
 
 # bearer:expected ruby_rails_sql_injection
 connection.select_all("SELECT #{params[:oops]}")
+
+class Foo
+  def bad(name)
+    # bearer:expected ruby_rails_sql_injection
+    connection.select_all("SELECT user WHERE name ='#{name}'")
+  end
+end

--- a/tests/ruby/rails/sql_injection/testdata/ok_sanitized.rb
+++ b/tests/ruby/rails/sql_injection/testdata/ok_sanitized.rb
@@ -9,3 +9,10 @@ joins("INNER JOIN t_#{params[:oops].to_i}")
 ActiveRecord::Base.connection.exec_query("SELECT #{connection.quote(params[:oops])}")
 
 connection.select_all("SELECT #{connection.quote(params[:oops])}")
+
+class Foo
+  def bad(name, count)
+    connection.select_all("SELECT user WHERE name =#{connection.quote(name)}")
+    connection.select_all("SELECT user LIMIT #{count.to_i}")
+  end
+end


### PR DESCRIPTION
## Description

Use external input (user and dynamic input) for all current SQLi rules. This may increase number of false positives for our SQLi rule, but we feel this is valid given the severity of the legitimate case of SQLi. That is, an FP is preferable to missing a valid injection vulnerability.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
