### PR TITLE
fix(js): non-literal filename rule

### DIFF
--- a/rules/javascript/lang/non_literal_fs_filename.yml
+++ b/rules/javascript/lang/non_literal_fs_filename.yml
@@ -2,7 +2,7 @@ imports:
   - javascript_shared_import_library
 patterns:
   - pattern: |
-      $<FS>.$<METHOD>($<...>$<INPUT>$<...>)
+      $<FS>.$<METHOD>($<INPUT>$<...>)
     filters:
       - variable: FS
         detection: javascript_lang_non_literal_fs_filename_fs_init
@@ -14,10 +14,6 @@ patterns:
           - chmod
           - chown
           - close
-          - copyFile
-          - copyFile
-          - cp
-          - cp
           - createReadStream
           - createWriteStream
           - exists
@@ -31,28 +27,22 @@ patterns:
           - lchmod
           - lchown
           - lutimes
-          - link
-          - link
           - lstat
           - mkdir
           - mkdtemp
           - open
+          - openAsBlob
           - opendir
-          - read
           - read
           - readdir
           - readFile
           - readlink
           - readv
           - realpath
-          - realpath
-          - rename
-          - rename
           - rmdir
           - rm
           - stat
-          - symlink
-          - symlink
+          - statfs
           - truncate
           - unlink
           - unwatchFile
@@ -67,10 +57,6 @@ patterns:
           - chmodSync
           - chownSync
           - closeSync
-          - copyFileSync
-          - copyFileSync
-          - cpSync
-          - cpSync
           - existsSync
           - fchmodSync
           - fchownSync
@@ -82,8 +68,6 @@ patterns:
           - lchmodSync
           - lchownSync
           - lutimesSync
-          - linkSync
-          - linkSync
           - lstatSync
           - mkdirSync
           - mkdtempSync
@@ -93,17 +77,11 @@ patterns:
           - readFileSync
           - readlinkSync
           - readSync
-          - readSync
           - readvSync
-          - realpathync
           - realpathSync
-          - renameSync
-          - renameSync
           - rmdirSync
           - rmSync
           - statSync
-          - symlinkSync
-          - symlinkSync
           - truncateSync
           - unlinkSync
           - utimesSync
@@ -114,6 +92,33 @@ patterns:
           variable: INPUT
           detection: string_literal
           scope: result
+  - pattern: |
+      $<FS>.$<METHOD>($<INPUT_1>, $<INPUT_2>$<...>)
+    filters:
+      - variable: FS
+        detection: javascript_lang_non_literal_fs_filename_fs_init
+        scope: cursor
+      - variable: METHOD
+        values:
+          - copyFile # copyFile(sourcePath, destPath)
+          - cp # cp(sourcePath, destPath)
+          - link # link(oldPath, newPath, ...)
+          - rename # rename(oldPath, newPath, ...)
+          - symlink # symlink(target, path)
+          - copyFileSync
+          - cpSync
+          - linkSync
+          - renameSync
+          - symlinkSync
+      - either:
+          - not:
+              variable: INPUT_1
+              detection: string_literal
+              scope: result
+          - not:
+              variable: INPUT_2
+              detection: string_literal
+              scope: result
 auxiliary:
   - id: javascript_lang_non_literal_fs_filename_fs_init
     patterns:

--- a/tests/javascript/lang/non_literal_fs_filename/testdata/app.js
+++ b/tests/javascript/lang/non_literal_fs_filename/testdata/app.js
@@ -11,6 +11,25 @@ export function bad(options) {
   }
 }
 
+export function bad2(options) {
+  // bearer:expected javascript_lang_non_literal_fs_filename
+  Fs.copyFileSync(options.filePath, 'some-new-filepath.txt', 'utf8');
+
+  // bearer:expected javascript_lang_non_literal_fs_filename
+  Fs.symlink('some-filepath.txt', options.filePath, 'utf8');
+
+  // bearer:expected javascript_lang_non_literal_fs_filename
+  Fs.rename(options.filePath, options.newFilePath);
+}
+
 export function ok() {
   stdioTarget = Fs.createWriteStream('some-string-literal', 'utf8');
+}
+
+export function ok2(data, encoding) {
+  stdioTarget = Fs.createWriteStream('some-string-literal', data, encoding);
+}
+
+export function ok3(data) {
+  Fs.symlink('some-filepath.txt', 'some-other-filepath.txt', data.options);
 }


### PR DESCRIPTION
## Description

Fix pattern for JS non-literal filename rule so that it does not catch on cases where e.g. filename is a string literal but subsequent args are not. 
Separate fs methods that take two filenames (e.g. `copyFile`)

Update test to reflect these cases

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
