### PR TITLE
fix: Java and JS SQLi rules and JS Express XXE rule

### DIFF
--- a/rules/java/shared/lang/dynamic_input.yml
+++ b/rules/java/shared/lang/dynamic_input.yml
@@ -9,6 +9,27 @@ patterns:
       - variable: DYNAMIC_INPUT
         detection: java_shared_lang_dynamic_input_input
         scope: cursor_strict
+  - pattern: $<DYNAMIC_INPUT>.$<METHOD>();
+    filters:
+      - variable: DYNAMIC_INPUT
+        detection: java_shared_lang_dynamic_input
+        scope: cursor
+      - variable: METHOD
+        values:
+          - getBytes
+          - replace
+          - replaceAll
+          - split
+          - substring
+          - toCharArray
+          - toLowerCase
+          - toString
+          - toUpperCase
+            # StringBuilder
+          - append
+          - toString
+            # Enumeration
+          - nextElement
   # array access
   - pattern: $<DYNAMIC_INPUT>[$<_>];
     filters:

--- a/rules/java/shared/lang/dynamic_input.yml
+++ b/rules/java/shared/lang/dynamic_input.yml
@@ -17,8 +17,8 @@ patterns:
       - variable: METHOD
         values:
           - getBytes
-          - replace
-          - replaceAll
+          # - replace # sanitizer
+          # - replaceAll # sanitizer
           - split
           - substring
           - toCharArray

--- a/rules/java/shared/lang/user_input.yml
+++ b/rules/java/shared/lang/user_input.yml
@@ -4,6 +4,27 @@ type: shared
 languages:
   - java
 patterns:
+  - pattern: $<USER_INPUT>.$<METHOD>()
+    filters:
+      - variable: USER_INPUT
+        detection: java_shared_lang_user_input
+        scope: cursor
+      - variable: METHOD
+        values:
+          - getBytes
+          - replace
+          - replaceAll
+          - split
+          - substring
+          - toCharArray
+          - toLowerCase
+          - toString
+          - toUpperCase
+            # StringBuilder
+          - append
+          - toString
+            # Enumeration
+          - nextElement
   - pattern: $<JAVA_SHARED_LANG_USER_INPUT_REQUEST>.$<JAVA_SHARED_LANG_USER_INPUT_METHOD>();
     filters:
       - variable: JAVA_SHARED_LANG_USER_INPUT_REQUEST

--- a/rules/java/shared/lang/user_input.yml
+++ b/rules/java/shared/lang/user_input.yml
@@ -4,7 +4,7 @@ type: shared
 languages:
   - java
 patterns:
-  - pattern: $<USER_INPUT>.$<METHOD>()
+  - pattern: $<USER_INPUT>.$<METHOD>();
     filters:
       - variable: USER_INPUT
         detection: java_shared_lang_user_input
@@ -12,8 +12,8 @@ patterns:
       - variable: METHOD
         values:
           - getBytes
-          - replace
-          - replaceAll
+          # - replace # sanitizer
+          # - replaceAll # sanitizer
           - split
           - substring
           - toCharArray

--- a/rules/javascript/express/xml_external_entity_vulnerability.yml
+++ b/rules/javascript/express/xml_external_entity_vulnerability.yml
@@ -33,13 +33,7 @@ patterns:
         values:
           - parse
           - write
-  - pattern: |
-      $<LIB_XML>.$<METHOD>(
-        $<_>,
-        {
-          $<!>noent: true
-        }
-      )
+  - pattern: $<LIB_XML>.$<METHOD>($<_>, $<INSECURE_OPTIONS>)
     filters:
       - variable: LIB_XML
         values:
@@ -51,6 +45,9 @@ patterns:
         values:
           - parseXml
           - parseXmlString
+      - variable: INSECURE_OPTIONS
+        detection: javascript_express_xxe_vulnerability_insecure_libxml_options
+        scope: result
   - pattern: | # xml2json
       parser.toXml($<USER_INPUT>$<...>)
     filters:
@@ -58,6 +55,12 @@ patterns:
         detection: javascript_shared_common_user_input
         scope: result
 auxiliary:
+  - id: javascript_express_xxe_vulnerability_insecure_libxml_options
+    patterns:
+      - |
+        {
+          $<!>noent: true
+        }
   - id: javascript_express_xxe_vulnerability_node_expat_parser
     patterns:
       - new expat.Parser()

--- a/rules/javascript/lang/sql_injection.yml
+++ b/rules/javascript/lang/sql_injection.yml
@@ -69,6 +69,25 @@ patterns:
       - variable: USER_INPUT
         detection: javascript_lang_sql_injection_user_input
         scope: result
+  - pattern: |
+      $<SQLITE_3_DB>.$<METHOD>($<USER_INPUT>$<...>)
+    filters:
+      - variable: SQLITE_3_DB
+        detection: javascript_lang_sql_injection_sqlite3_init
+        scope: cursor
+      - variable: METHOD
+        values:
+          - all
+          - each
+          - exec
+          - get
+          - map
+          - prepare
+          - run
+      - variable: USER_INPUT
+        detection: javascript_lang_sql_injection_user_input
+        scope: result
+
 auxiliary:
   - id: javascript_lang_sql_injection_user_input
     sanitizer: javascript_lang_sql_injection_sanitizer
@@ -84,6 +103,9 @@ auxiliary:
   - id: javascript_lang_sql_injection_sequelize_init
     patterns:
       - new Sequelize()
+  - id: javascript_lang_sql_injection_sqlite3_init
+    patterns:
+      - new sqlite3.Database()
   - id: javascript_lang_sql_injection_mysql_conn
     patterns:
       - mysql.createConnection()

--- a/tests/java/lang/sqli/testdata/bad.java
+++ b/tests/java/lang/sqli/testdata/bad.java
@@ -49,10 +49,11 @@ public class SQLExample {
       x.createQuery("select " + request.getParameter("id"));
    }
 
-   public static void dynamicVarTest(EntityManager x, String someString, String[] args) {
+   public static void dynamicVarTest(EntityManager x, String name, String[] args) {
+      String queryStr = "select name, email, headline, phone_no from employee where lower(name) like '%" + name.toLowerCase() + "%'";
       // bearer:expected java_lang_sqli
-      x.createQuery("select " + someString);
+      x.createQuery(queryStr);
       // bearer:expected java_lang_sqli
-      x.createQuery("select " + args[1]);
+      x.createNativeQuery("select " + args[1]);
    }
 }

--- a/tests/javascript/express/xml_external_entity_vulnerability/testdata/lib_xml_with_noent_true.js
+++ b/tests/javascript/express/xml_external_entity_vulnerability/testdata/lib_xml_with_noent_true.js
@@ -3,3 +3,7 @@ var xml =  '<?xml version="1.0" encoding="UTF-8"?><root></root>';
 
 // bearer:expected javascript_express_xml_external_entity_vulnerability
 libxml.parseXmlString(xml, { noent: true, noblanks: true });
+
+var options = { noent: true, noblanks: true }
+// bearer:expected javascript_express_xml_external_entity_vulnerability
+libxml.parseXmlString(xml, options);

--- a/tests/javascript/lang/sql_injection/test.js
+++ b/tests/javascript/lang/sql_injection/test.js
@@ -7,7 +7,7 @@ const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
 describe(ruleId, () => {
   const invoke = createNewInvoker(ruleId, ruleFile, testBase)
 
-  
+
     test("knex_sql_injection", () => {
       const testCase = "knex_sql_injection.js"
 
@@ -16,7 +16,7 @@ describe(ruleId, () => {
       expect(results.Missing).toEqual([])
       expect(results.Extra).toEqual([])
     })
-  
+
 
     test("mysql2_sql_injection", () => {
       const testCase = "mysql2_sql_injection.js"
@@ -26,7 +26,7 @@ describe(ruleId, () => {
       expect(results.Missing).toEqual([])
       expect(results.Extra).toEqual([])
     })
-  
+
 
     test("ok_no_sql_injection", () => {
       const testCase = "ok_no_sql_injection.js"
@@ -36,7 +36,7 @@ describe(ruleId, () => {
       expect(results.Missing).toEqual([])
       expect(results.Extra).toEqual([])
     })
-  
+
 
     test("pg_sql_injection", () => {
       const testCase = "pg_sql_injection.js"
@@ -46,7 +46,7 @@ describe(ruleId, () => {
       expect(results.Missing).toEqual([])
       expect(results.Extra).toEqual([])
     })
-  
+
 
     test("sequelize_sql_injection", () => {
       const testCase = "sequelize_sql_injection.js"
@@ -56,7 +56,7 @@ describe(ruleId, () => {
       expect(results.Missing).toEqual([])
       expect(results.Extra).toEqual([])
     })
-  
+
 
     test("sql_injection_juice", () => {
       const testCase = "sql_injection_juice.js"
@@ -66,7 +66,7 @@ describe(ruleId, () => {
       expect(results.Missing).toEqual([])
       expect(results.Extra).toEqual([])
     })
-  
+
 
     test("sql_injection_juice_safe", () => {
       const testCase = "sql_injection_juice_safe.ts"
@@ -76,5 +76,15 @@ describe(ruleId, () => {
       expect(results.Missing).toEqual([])
       expect(results.Extra).toEqual([])
     })
-  
+
+
+    test("sqlite3_sql_injection", () => {
+      const testCase = "sqlite3_sql_injection.js"
+
+      const results = invoke(testCase)
+
+      expect(results.Missing).toEqual([])
+      expect(results.Extra).toEqual([])
+    })
+
 })

--- a/tests/javascript/lang/sql_injection/testdata/sqlite3_sql_injection.js
+++ b/tests/javascript/lang/sql_injection/testdata/sqlite3_sql_injection.js
@@ -1,0 +1,12 @@
+const sqlite3 = require('sqlite3')
+const db = new sqlite3.Database(':memory:')
+
+export function searchEmployees(term) {
+  return new Promise((resolve, reject) => {
+    // bearer:expected javascript_lang_sql_injection
+    db.all("SELECT * FROM employees WHERE name LIKE '%"+term+"%'", (err, rows) => {
+      if (err) reject(err)
+      else resolve(rows)
+    })
+  })
+}


### PR DESCRIPTION
## Description

* Fix Java dynamic and user input so that we still consider things like `external.toLowerCase()` as external input
* Add sqlite 3 case to JS SQLi rule
* Handle case with dynamic options for JS Express XXE LibXML case

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
