### PR TITLE
feat(python): exception message rule (CWE-210)

### DIFF
--- a/rules/python/lang/exception.yml
+++ b/rules/python/lang/exception.yml
@@ -2,13 +2,19 @@ imports:
   - python_shared_lang_datatype
 patterns:
   - pattern: |
-      raise $<_>($<DATA_TYPE>)
+      raise $<DATA_TYPE>
     filters:
       - variable: DATA_TYPE
         detection: python_shared_lang_datatype
         scope: result
   - pattern: |
-      raise $<_>($<DATA_TYPE>) from $<_>
+      raise $<DATA_TYPE> from $<_>
+    filters:
+      - variable: DATA_TYPE
+        detection: python_shared_lang_datatype
+        scope: result
+  - pattern: |
+      raise $<_> from $<DATA_TYPE>
     filters:
       - variable: DATA_TYPE
         detection: python_shared_lang_datatype

--- a/rules/python/lang/exception.yml
+++ b/rules/python/lang/exception.yml
@@ -7,6 +7,12 @@ patterns:
       - variable: DATA_TYPE
         detection: python_shared_lang_datatype
         scope: result
+  - pattern: |
+      raise $<_>($<DATA_TYPE>) from $<_>
+    filters:
+      - variable: DATA_TYPE
+        detection: python_shared_lang_datatype
+        scope: result
 languages:
   - python
 skip_data_types:

--- a/rules/python/lang/exception.yml
+++ b/rules/python/lang/exception.yml
@@ -1,0 +1,35 @@
+imports:
+  - python_shared_lang_datatype
+patterns:
+  - pattern: |
+      raise $<_>($<DATA_TYPE>)
+    filters:
+      - variable: DATA_TYPE
+        detection: python_shared_lang_datatype
+        scope: result
+languages:
+  - python
+skip_data_types:
+  - Unique Identifier
+severity: medium
+metadata:
+  description: Leakage of sensitive data in exception message
+  remediation_message: |-
+    ## Description
+
+    Leakage of sensitive data in exception messages can lead to data breaches. This vulnerability occurs when sensitive information is included in exceptions, making it accessible to unauthorized users.
+
+    ## Remediations
+
+    - **Do not** include sensitive data in exception messages. This can inadvertently expose private information.
+      ```python
+      raise Exception(f"User '{user.email}' is unauthorized") # unsafe
+      ```
+    - **Do** use non-sensitive, unique identifiers in exception messages to avoid revealing personal information.
+      ```python
+      raise Exception(f"User '{user.uuid}' is unauthorized") # unsafe
+      ```
+  cwe_id:
+    - 210
+  id: python_lang_exception
+  documentation_url: https://docs.bearer.com/reference/rules/python_lang_exception

--- a/tests/python/lang/exception/test.js
+++ b/tests/python/lang/exception/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("exception", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/lang/exception/testdata/main.py
+++ b/tests/python/lang/exception/testdata/main.py
@@ -4,6 +4,13 @@ def bad(user):
     raise CustomError(f"User '{user.email}' is unauthorized")
     # bearer:expected python_lang_exception
     raise Exception(f"User '{user.email}' is unauthorized")
+    
+def bad2(user):
+  try: 
+    user.save()
+  except Exception as e:
+    # bearer:expected python_lang_exception
+    raise BadUserException(f"User can't be saved: " + user.email) from e
 
 def ok(user)
   if not user.logged_in:

--- a/tests/python/lang/exception/testdata/main.py
+++ b/tests/python/lang/exception/testdata/main.py
@@ -1,0 +1,11 @@
+def bad(user):
+  if not user.logged_in:
+    # bearer:expected python_lang_exception
+    raise CustomError(f"User '{user.email}' is unauthorized")
+    # bearer:expected python_lang_exception
+    raise Exception(f"User '{user.email}' is unauthorized")
+
+def ok(user)
+  if not user.logged_in:
+    raise CustomError(f"User '{user.uuid}' is unauthorized")
+  


### PR DESCRIPTION
## Description

Add rule against sensitive data leaking in exception messages

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
