### PR TITLE
feat(python): add shared rules for imports

### DIFF
--- a/rules/python/shared/lang/import1.yml
+++ b/rules/python/shared/lang/import1.yml
@@ -1,0 +1,22 @@
+type: shared
+languages:
+  - python
+patterns:
+  - pattern: $<IMPORTED_MODULE1>.$<NAME>
+    filters:
+      - variable: IMPORTED_MODULE1
+        detection: python_shared_lang_import1_module1
+        scope: cursor
+        imports:
+          - variable: MODULE1
+            as: MODULE1
+  - from $<MODULE1> import $<NAME> as $<!>$<_>
+  - from $<MODULE1> import $<!>$<NAME>
+auxiliary:
+  - id: python_shared_lang_import1_module1
+    patterns:
+      - import $<!>$<MODULE1>
+      - import $<MODULE1> as $<!>$<_>
+metadata:
+  description: "Python import level 1."
+  id: python_shared_lang_import1

--- a/rules/python/shared/lang/import2.yml
+++ b/rules/python/shared/lang/import2.yml
@@ -1,0 +1,38 @@
+type: shared
+languages:
+  - python
+patterns:
+  - pattern: $<IMPORTED_MODULE2>.$<NAME>
+    filters:
+      - variable: IMPORTED_MODULE2
+        detection: python_shared_lang_import2_module2
+        scope: cursor
+        imports:
+          - variable: MODULE1
+            as: MODULE1
+          - variable: MODULE2
+            as: MODULE2
+  - from $<MODULE1>.$<MODULE2> import $<NAME> as $<!>$<_>
+  - from $<MODULE1>.$<MODULE2> import $<!>$<NAME>
+auxiliary:
+  - id: python_shared_lang_import2_module1
+    patterns:
+      - import $<!>$<MODULE1>
+      - import $<!>$<MODULE1>.$<MODULE2>
+      - import $<MODULE1> as $<!>$<_>
+  - id: python_shared_lang_import2_module2
+    patterns:
+      - pattern: $<IMPORTED_MODULE1>.$<MODULE2>
+        filters:
+          - variable: IMPORTED_MODULE1
+            detection: python_shared_lang_import2_module1
+            scope: cursor
+            imports:
+              - variable: MODULE1
+                as: MODULE1
+      - import $<MODULE1>.$<MODULE2> as $<!>$<_>
+      - from $<MODULE1> import $<!>$<MODULE2>
+      - from $<MODULE1> import $<MODULE2> as $<!>$<_>
+metadata:
+  description: "Python import level 2."
+  id: python_shared_lang_import2

--- a/rules/python/shared/lang/import3.yml
+++ b/rules/python/shared/lang/import3.yml
@@ -1,0 +1,56 @@
+type: shared
+languages:
+  - python
+patterns:
+  - pattern: $<IMPORTED_MODULE3>.$<NAME>
+    filters:
+      - variable: IMPORTED_MODULE3
+        detection: python_shared_lang_import3_module3
+        scope: cursor
+        imports:
+          - variable: MODULE1
+            as: MODULE1
+          - variable: MODULE2
+            as: MODULE2
+          - variable: MODULE3
+            as: MODULE3
+  - from $<MODULE1>.$<MODULE2>.$<MODULE3> import $<NAME> as $<!>$<_>
+  - from $<MODULE1>.$<MODULE2>.$<MODULE3> import $<!>$<NAME>
+auxiliary:
+  - id: python_shared_lang_import3_module1
+    patterns:
+      - import $<!>$<MODULE1>
+      - import $<!>$<MODULE1>.$<MODULE2>
+      - import $<!>$<MODULE1>.$<MODULE2>.$<MODULE3>
+      - import $<MODULE1> as $<!>$<_>
+  - id: python_shared_lang_import3_module2
+    patterns:
+      - pattern: $<IMPORTED_MODULE1>.$<MODULE2>
+        filters:
+          - variable: IMPORTED_MODULE1
+            detection: python_shared_lang_import3_module1
+            scope: cursor
+            imports:
+              - variable: MODULE1
+                as: MODULE1
+      - import $<MODULE1>.$<MODULE2> as $<!>$<_>
+      - from $<MODULE1> import $<!>$<MODULE2>
+      - from $<MODULE1> import $<MODULE2> as $<!>$<_>
+  - id: python_shared_lang_import3_module3
+    patterns:
+      - pattern: $<IMPORTED_MODULE2>.$<MODULE3>
+        filters:
+          - variable: IMPORTED_MODULE2
+            detection: python_shared_lang_import3_module2
+            scope: cursor
+            imports:
+              - variable: MODULE1
+                as: MODULE1
+              - variable: MODULE2
+                as: MODULE2
+      - import $<MODULE1>.$<MODULE2>.$<MODULE3> as $<!>$<_>
+      - from $<MODULE1>.$<MODULE2> import $<!>$<MODULE3>
+      - from $<MODULE1>.$<MODULE2> import $<MODULE3> as $<!>$<_>
+metadata:
+  description: "Python import level 3."
+  id: python_shared_lang_import3

--- a/rules/python/shared/lang/import4.yml
+++ b/rules/python/shared/lang/import4.yml
@@ -1,0 +1,76 @@
+type: shared
+languages:
+  - python
+patterns:
+  - pattern: $<IMPORTED_MODULE4>.$<NAME>
+    filters:
+      - variable: IMPORTED_MODULE4
+        detection: python_shared_lang_import4_module4
+        scope: cursor
+        imports:
+          - variable: MODULE1
+            as: MODULE1
+          - variable: MODULE2
+            as: MODULE2
+          - variable: MODULE3
+            as: MODULE3
+          - variable: MODULE4
+            as: MODULE4
+  - from $<MODULE1>.$<MODULE2>.$<MODULE3>.$<MODULE4> import $<NAME> as $<!>$<_>
+  - from $<MODULE1>.$<MODULE2>.$<MODULE3>.$<MODULE4> import $<!>$<NAME>
+auxiliary:
+  - id: python_shared_lang_import4_module1
+    patterns:
+      - import $<!>$<MODULE1>
+      - import $<!>$<MODULE1>.$<MODULE2>
+      - import $<!>$<MODULE1>.$<MODULE2>.$<MODULE3>
+      - import $<!>$<MODULE1>.$<MODULE2>.$<MODULE3>.$<MODULE4>
+      - import $<MODULE1> as $<!>$<_>
+  - id: python_shared_lang_import4_module2
+    patterns:
+      - pattern: $<IMPORTED_MODULE1>.$<MODULE2>
+        filters:
+          - variable: IMPORTED_MODULE1
+            detection: python_shared_lang_import4_module1
+            scope: cursor
+            imports:
+              - variable: MODULE1
+                as: MODULE1
+      - import $<MODULE1>.$<MODULE2> as $<!>$<_>
+      - from $<MODULE1> import $<!>$<MODULE2>
+      - from $<MODULE1> import $<MODULE2> as $<!>$<_>
+  - id: python_shared_lang_import4_module3
+    patterns:
+      - pattern: $<IMPORTED_MODULE2>.$<MODULE3>
+        filters:
+          - variable: IMPORTED_MODULE2
+            detection: python_shared_lang_import4_module2
+            scope: cursor
+            imports:
+              - variable: MODULE1
+                as: MODULE1
+              - variable: MODULE2
+                as: MODULE2
+      - import $<MODULE1>.$<MODULE2>.$<MODULE3> as $<!>$<_>
+      - from $<MODULE1>.$<MODULE2> import $<!>$<MODULE3>
+      - from $<MODULE1>.$<MODULE2> import $<MODULE3> as $<!>$<_>
+  - id: python_shared_lang_import4_module4
+    patterns:
+      - pattern: $<IMPORTED_MODULE3>.$<MODULE4>
+        filters:
+          - variable: IMPORTED_MODULE3
+            detection: python_shared_lang_import4_module3
+            scope: cursor
+            imports:
+              - variable: MODULE1
+                as: MODULE1
+              - variable: MODULE2
+                as: MODULE2
+              - variable: MODULE3
+                as: MODULE3
+      - import $<MODULE1>.$<MODULE2>.$<MODULE3>.$<MODULE4> as $<!>$<_>
+      - from $<MODULE1>.$<MODULE2>.$<MODULE3> import $<!>$<MODULE4>
+      - from $<MODULE1>.$<MODULE2>.$<MODULE3> import $<MODULE4> as $<!>$<_>
+metadata:
+  description: "Python import level 4."
+  id: python_shared_lang_import4


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds Python shared rules for handling imported names. These are specific to the number of nested levels of modules being imported.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
