### PR TITLE
fix(python): shared input rules to use import wherever possible

### DIFF
--- a/rules/python/shared/django/user_input.yml
+++ b/rules/python/shared/django/user_input.yml
@@ -19,7 +19,8 @@ patterns:
   - pattern: $<FORM>.$<METHOD>[$<_>]
     filters:
       - variable: FORM
-        regex: \A(un)?(bound_)?form\z
+        detection: python_shared_django_user_input_form
+        scope: result
       - variable: METHOD
         values:
           - data
@@ -28,9 +29,19 @@ patterns:
   - pattern: $<FORM>[$<_>].value()
     filters:
       - variable: FORM
-        regex: \A(un)?(bound_)?form\z
+        detection: python_shared_django_user_input_form
+        scope: result
 auxiliary:
+  - id: python_shared_django_user_input_form
+    patterns:
+      - pattern: $<FORM>
+        # from <some_form_module> import <SomeFormName>
+        # form = FormName(request.POST)
+        filters:
+          - variable: FORM
+            regex: \A(un)?(bound_)?form\z
   - id: python_shared_django_user_input_request
+    # passed to a view method e.g. def my_view(request)
     patterns:
       - request
       - req

--- a/rules/python/shared/lang/dynamic_input.yml
+++ b/rules/python/shared/lang/dynamic_input.yml
@@ -1,6 +1,8 @@
 type: shared
 languages:
   - python
+imports:
+  - python_shared_lang_import1
 patterns:
   - sys.argv[$<_>]
   - pattern: $<PARSER>.parse_args($<...>)
@@ -8,36 +10,29 @@ patterns:
       - variable: PARSER
         detection: python_shared_lang_dynamic_input_parser
         scope: result
-  - pattern: $<GETOPT>.getopt($<...>)
+  - pattern: $<GETOPT>($<...>)
     filters:
       - variable: GETOPT
-        detection: python_shared_lang_dynamic_input_getopt
-        scope: result
+        detection: python_shared_lang_import1
+        scope: cursor
+        filters:
+          - variable: MODULE1
+            values: [getopt]
+          - variable: NAME
+            values: [getopt]
 auxiliary:
   - id: python_shared_lang_dynamic_input_parser
     patterns:
       - pattern: $<ARG_PARSER>()
         filters:
           - variable: ARG_PARSER
-            detection: python_shared_lang_dynamic_input_argument_parser
-  - id: python_shared_lang_dynamic_input_argument_parser
-    patterns:
-      - ArgumentParser # fallback
-      - from argparse import ArgumentParser as $<!>$<_>
-      - pattern: $<ARGPARSE>.ArgumentParser
-        filters:
-          - variable: ARGPARSE
-            detection: python_shared_lang_dynamic_input_argparse_import
-  - id: python_shared_lang_dynamic_input_argparse_import
-    patterns:
-      - import $<!>argparse
-      - import argparse as $<!>$<_>
-      - argparse # fallback
-  - id: python_shared_lang_dynamic_input_getopt
-    patterns:
-      - import $<!>getopt
-      - import getopt as $<!>$<_>
-      - getopt # fallback
+            detection: python_shared_lang_import1
+            scope: cursor
+            filters:
+              - variable: MODULE1
+                values: [argparse]
+              - variable: NAME
+                values: [ArgumentParser]
 metadata:
   description: "Python dynamic input."
   id: python_shared_lang_dynamic_input


### PR DESCRIPTION
## Description

Update python lang dynamic input rule to use shared "import" rule
Add comments to django user input rule - I don't think it is possible to use "import"s here? 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
