### PR TITLE
fix(php): symfony SQLi sanitizer

### DIFF
--- a/rules/php/symfony/sql_injection.yml
+++ b/rules/php/symfony/sql_injection.yml
@@ -48,7 +48,9 @@ auxiliary:
             scope: cursor
   - id: php_symfony_sql_injection_input_sanitizer
     patterns:
+      - pattern: $<_>->createNamedParameter($<!>$<_>)
       - pattern: $<_>->quote($<!>$<_>)
+      - pattern: $<_>->setParameter($<!>$<_>)
 languages:
   - php
 severity: critical

--- a/tests/php/symfony/sql_injection/testdata/injection-query-builder.php
+++ b/tests/php/symfony/sql_injection/testdata/injection-query-builder.php
@@ -23,4 +23,11 @@ class FooRepository extends ServiceEntityRepository
         $data = $query->getResult();
         return $data;
     }
+    
+    public function okay(): array
+    {
+      $queryBuilder->where(
+        $queryBuilder->expr()->like('name', $queryBuilder->createNamedParameter($_GET['username'])
+      );
+    }
 }


### PR DESCRIPTION
## Description

Extend PHP symfony SQLi sanitizer  to include `createNamedParameter()` and `setParameter()` methods

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
