### PR TITLE
feat(python): add shared instance rule

### DIFF
--- a/rules/python/shared/lang/instance.yml
+++ b/rules/python/shared/lang/instance.yml
@@ -1,0 +1,13 @@
+type: shared
+languages:
+  - python
+patterns:
+  - $<CLASS>($<...>)
+  - |
+    class $<_>($<CLASS>):
+      def $<_>($<!>self$<...>):
+  - |
+    def $<_>($<...>$<!>$<_>: $<CLASS>$<...>):
+metadata:
+  description: "Python CLASS instance"
+  id: python_shared_lang_instance


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Adds a shared rule for matching instances of a class. Matches the following examples:

```python
MatchedClass(a, b)

class Unimportant(MatchedClass):
  def f(self, x): # self is matched as an instance
    ...

def m(x: MatchedClass): # x is matched as an instance
  ...

```

This can be composed with the import rules to match a specific type. eg:

```yaml
  - pattern: $<INSTANCE>
    filters:
      - variable: INSTANCE
        detection: python_shared_lang_instance
        scope: cursor_strict
        filters:
          - variable: CLASS
            detection: python_shared_lang_import2
            scope: cursor
            filters:
              - variable: MODULE1
                values: [http]
              - variable: MODULE2
                values: [server]
              - variable: NAME
                values: [BaseHTTPRequestHandler]
```

Needs: https://github.com/Bearer/bearer/pull/1597

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
