### PR TITLE
feat(python): bind to all interfaces (CWE-200)

### DIFF
--- a/rules/python/lang/bind_to_all_interfaces.yml
+++ b/rules/python/lang/bind_to_all_interfaces.yml
@@ -1,0 +1,45 @@
+imports:
+  - python_shared_lang_import1
+patterns:
+  - pattern: $<SOCKET>.bind($<PERMISSIVE_ADDR>$<...>)
+    filters:
+      - variable: SOCKET
+        detection: python_lang_bind_to_all_interfaces_socket
+      - variable: PERMISSIVE_ADDR
+        # "0.0.0.0", "::", or ""
+        string_regex: \A(0\.0\.0\.0|\:\:|^$)\z
+auxiliary:
+  - id: python_lang_bind_to_all_interfaces_socket
+    patterns:
+      - pattern: $<SOCKET>()
+        filters:
+          - variable: SOCKET
+            detection: python_shared_lang_import1
+            scope: cursor
+            filters:
+              - variable: MODULE1
+                values: [socket]
+              - variable: NAME
+                values: [socket]
+languages:
+  - python
+severity: medium
+metadata:
+  description: Permissive server network interface configuration
+  remediation_message: |-
+    ## Description
+
+    Binding a service to "0.0.0.0" (or an empty string) makes it accessible on all network interfaces. This configuration can lead to unintended exposure over insecure or unintended network interfaces, creating potential security risks.
+
+    ## Remediations
+
+    - **Do not** bind services to "0.0.0.0" without considering the security implications. This default setting can expose your service on all network interfaces, including those that are not secure.
+    - **Do** bind your service to a specific IP address or network interface to limit access and enhance security. This can be achieved through various methods:
+        - Specify the IP address using an environment variable for flexible and secure configuration.
+        - Define the IP address in a configuration file that the application reads at startup.
+        - Dynamically identify the appropriate network interface and bind the service to its IP address.
+    - **Do** implement security best practices when configuring network services. Use firewalls to control access and encrypt communication with TLS to protect data in transit.
+  cwe_id:
+    - 200
+  id: python_lang_bind_to_all_interfaces
+  documentation_url: https://docs.bearer.com/reference/rules/python_lang_bind_to_all_interfaces

--- a/tests/python/lang/bind_to_all_interfaces/test.js
+++ b/tests/python/lang/bind_to_all_interfaces/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("bind_to_all_interfaces", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/lang/bind_to_all_interfaces/testdata/main.py
+++ b/tests/python/lang/bind_to_all_interfaces/testdata/main.py
@@ -1,0 +1,17 @@
+import socket
+
+def bad():
+  my_socket = socket.socket()
+  # bearer:expected python_lang_bind_to_all_interfaces
+  my_socket.bind("0.0.0.0")
+  # bearer:expected python_lang_bind_to_all_interfaces
+  my_socket.bind("::")
+  # bearer:expected python_lang_bind_to_all_interfaces
+  my_socket.bind('')
+  
+ 
+ KNOWN_SOCKET = "123.123.123" 
+ def ok():
+  my_safe_socket = socket.socket()
+  my_safe_socket.bind("123.456.789")
+  my_safe_socket.bind(KNOWN_SOCKET)


### PR DESCRIPTION
## Description

Add Python rule to catch cases of binding to all interfaces, which can lead to unintentional information exposure over insecure network

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
