### PR TITLE
fix(php)(symfony): multiple parameters for SQLi sanitization method

### DIFF
--- a/rules/php/symfony/sql_injection.yml
+++ b/rules/php/symfony/sql_injection.yml
@@ -48,9 +48,9 @@ auxiliary:
             scope: cursor
   - id: php_symfony_sql_injection_input_sanitizer
     patterns:
-      - pattern: $<_>->createNamedParameter($<!>$<_>)
       - pattern: $<_>->quote($<!>$<_>)
-      - pattern: $<_>->setParameter($<!>$<_>)
+      - pattern: $<_>->createNamedParameter($<!>$<_>$<...>)
+      - pattern: $<_>->setParameter($<!>$<_>$<...>)
 languages:
   - php
 severity: critical

--- a/tests/php/symfony/sql_injection/testdata/injection-query-builder.php
+++ b/tests/php/symfony/sql_injection/testdata/injection-query-builder.php
@@ -23,11 +23,11 @@ class FooRepository extends ServiceEntityRepository
         $data = $query->getResult();
         return $data;
     }
-    
+
     public function okay(): array
     {
       $queryBuilder->where(
-        $queryBuilder->expr()->like('name', $queryBuilder->createNamedParameter($_GET['username'])
+        $queryBuilder->expr()->like('name', $this->queryBuilder->createNamedParameter($_GET['username'], Connection::PARAM_STR))
       );
     }
 }


### PR DESCRIPTION
## Description

Both `createNamedParameter` and `setParameter` can take multiple arguments.
Update sanitizer method for SQLi rule to reflect this. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
