### PR TITLE
feat(python/django): secure configuration failure (CWE-693)

### DIFF
--- a/rules/python/django/insecure_cookie_settings.yml
+++ b/rules/python/django/insecure_cookie_settings.yml
@@ -1,0 +1,38 @@
+patterns:
+  - pattern: SESSION_COOKIE_SECURE = $<FALSE>
+    filters:
+      - variable: "FALSE"
+        detection: python_django_insecure_cookie_settings_false
+        scope: result
+  - pattern: CSRF_COOKIE_SECURE = $<FALSE>
+    filters:
+      - variable: "FALSE"
+        detection: python_django_insecure_cookie_settings_false
+        scope: result
+auxiliary:
+  - id: python_django_insecure_cookie_settings_false
+    patterns:
+      - "False"
+languages:
+  - python
+severity: medium
+metadata:
+  description: Usage of insecure cookie settings
+  remediation_message: |
+    ## Description
+
+    Using insecure cookie settings when configuring your application poses a significant security risk. If session (or CSRF) cookies are transmitted over an unencrypted HTTP connection, an attacker could capture a cookie and use this to hijack a user's session, thereby gaining unauthorized access to - potentially sensitive - data and resources. 
+
+    To prevent this vulnerability, always enable to secure attributes for session and CSRF cookies in your settings.py file. This is especially important for production environments.  
+
+    ## Remediations
+
+    - **Do not** disable secure session cookies or CSRF cookies in production environments
+    ```python
+      SESSION_COOKIE_SECURE = False # unsafe
+      CSRF_COOKIE_SECURE = False # unsafe
+    ```
+  cwe_id:
+    - 693
+  id: python_django_insecure_cookie_settings
+  documentation_url: https://docs.bearer.com/reference/rules/python_django_insecure_cookie_settings

--- a/tests/python/django/insecure_cookie_settings/test.js
+++ b/tests/python/django/insecure_cookie_settings/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("insecure_cookie_settings", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/django/insecure_cookie_settings/testdata/main.py
+++ b/tests/python/django/insecure_cookie_settings/testdata/main.py
@@ -1,0 +1,8 @@
+ # bearer:expected python_django_insecure_cookie_settings
+SESSION_COOKIE_SECURE = False
+# bearer:expected python_django_insecure_cookie_settings
+CSRF_COOKIE_SECURE = False
+
+# ok
+SESSION_COOKIE_SECURE = TRUE
+CSRF_COOKIE_SECURE = True


### PR DESCRIPTION
## Description

Add rule for insecure configuration of Django cookie settings - CWE-693

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
