### PR TITLE
feat(python): add datadog third parties rule (CWE-201)

### DIFF
--- a/rules/python/third_parties/datadog.yml
+++ b/rules/python/third_parties/datadog.yml
@@ -1,0 +1,62 @@
+imports:
+  - python_shared_lang_datatype
+  - python_shared_lang_import2
+patterns:
+  - pattern: |
+      $<DD_SPAN>.$<METHOD>($<...>$<DATA_TYPE>$<...>)
+    filters:
+      - variable: DD_SPAN
+        detection: python_third_parties_datadog_span
+        scope: result
+      - variable: METHOD
+        values:
+          - set_tag
+          - set_tags
+          - set_struct_tag
+          - set_tag_str
+      - variable: DATA_TYPE
+        detection: python_shared_lang_datatype
+        scope: result
+auxiliary:
+  - id: python_third_parties_datadog_span
+    patterns:
+      - pattern: $<TRACER>($<...>)
+        filters:
+          - variable: TRACER
+            detection: python_shared_lang_import2
+            scope: cursor
+            filters:
+              - variable: MODULE1
+                values: [ddtrace]
+              - variable: MODULE2
+                values: [tracer]
+              - variable: NAME
+                values:
+                  - trace
+                  - start_span
+                  - current_span
+                  - current_root_span
+languages:
+  - python
+severity: medium
+skip_data_types:
+  - Unique Identifier
+metadata:
+  description: Leakage of sensitive data to Datadog
+  remediation_message: |
+    ## Description
+
+    Leaking sensitive data to third-party loggers like Datadog is a common cause of data leaks and can lead to data breaches.
+
+    ## Remediations
+
+    - **Do** ensure all sensitive data is removed when sending data to third-party loggers like Datadog.
+
+    ## References
+    - [Datadog docs](https://docs.datadoghq.com)
+    - [Scrubbing data](https://docs.datadoghq.com/tracing/configure_data_security/?tab=python#scrub-sensitive-data-from-your-spans)
+  cwe_id:
+    - 201
+  associated_recipe: Datadog
+  id: python_third_parties_datadog
+  documentation_url: https://docs.bearer.com/reference/rules/python_third_parties_datadog

--- a/tests/python/third_parties/datadog/test.js
+++ b/tests/python/third_parties/datadog/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("datadog", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/third_parties/datadog/testdata/main.py
+++ b/tests/python/third_parties/datadog/testdata/main.py
@@ -1,0 +1,19 @@
+from ddtrace import tracer
+
+@tracer.wrap()
+def execute():
+  span = tracer.current_span()
+  # bearer:expected python_third_parties_datadog
+  span.set_tag('user', user.email)
+  
+span = tracer.start_span("web.request")
+# bearer:expected python_third_parties_datadog
+span.set_tags('user', user.email)
+  
+span = tracer.trace("web.request")
+# bearer:expected python_third_parties_datadog
+span.set_struct_tag('user', { "email": user.email })
+
+root_span = tracer.current_root_span()
+# bearer:expected python_third_parties_datadog
+span.set_tag_str('user', user.email)


### PR DESCRIPTION
## Description

Add Python third parties rule for Datadog

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
