### PR TITLE
fix: python rules

### DIFF
--- a/rules/python/lang/deserialization_of_user_input.yml
+++ b/rules/python/lang/deserialization_of_user_input.yml
@@ -105,7 +105,7 @@ patterns:
         values:
           - load
           - persistent_load
-  - pattern: $<UNSAFE_RUAMEL_YAML>.load($<USER_DATA>$<...>)
+  - pattern: $<UNSAFE_RUAMEL_YAML>.load($<USER_INPUT>$<...>)
     filters:
       - variable: UNSAFE_RUAMEL_YAML
         detection: python_lang_deserialization_of_user_input_unsafe_ruamel_yaml

--- a/rules/python/third_parties/airbrake.yml
+++ b/rules/python/third_parties/airbrake.yml
@@ -14,7 +14,7 @@ patterns:
       - variable: DATA_TYPE
         detection: python_shared_lang_datatype
         scope: result
-  - pattern: $<NOTICE>[$<...>][$<...>] = $<...>$<DATA_TYPE>$<...>
+  - pattern: $<NOTICE>[$<_>][$<_>] = $<...>$<DATA_TYPE>$<...>
     filters:
       - variable: NOTICE
         detection: python_third_parties_airbrake_build_notice


### PR DESCRIPTION
## Description

* Fix pattern issue in Airbrake rule
* Fix typo in pattern variable for deserialization rule

It seems these kinds of issues are not picked up by our schema validator or by the bearer-rules unit tests, but rather cause null pointer issues in the engine when run on real-world repositories (which is done manually as part of the release process). We need to investigate why the unit tests for these two rules were able to pass -- seems strange that they were working 🤔 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
