### PR TITLE
feat(python): add elasticsearch third party rule (CWE-201)

### DIFF
--- a/rules/python/third_parties/elasticsearch.yml
+++ b/rules/python/third_parties/elasticsearch.yml
@@ -1,0 +1,49 @@
+imports:
+  - python_shared_lang_datatype
+  - python_shared_lang_instance
+  - python_shared_lang_import1
+patterns:
+  - pattern: $<CLIENT>.$<METHOD>($<...>$<DATA_TYPE>$<...>)
+    filters:
+      - variable: CLIENT
+        detection: python_shared_lang_instance
+        scope: cursor
+        filters:
+          - variable: CLASS
+            detection: python_shared_lang_import1
+            scope: cursor
+            filters:
+              - variable: MODULE1
+                values: [elasticsearch]
+              - variable: NAME
+                values: [Elasticsearch]
+      - variable: METHOD
+        values:
+          - update
+          - index
+      - variable: DATA_TYPE
+        detection: python_shared_lang_datatype
+        scope: result
+languages:
+  - python
+severity: medium
+skip_data_types:
+  - Unique Identifier
+metadata:
+  description: Leakage of sensitive data to ElasticSearch
+  remediation_message: |
+    ## Description
+
+    Leaking sensitive data to third-party data tools is a common cause of data leaks and can lead to data breaches.
+
+    ## Remediations
+
+    - **Do** ensure all sensitive data is removed when sending data to third-party services like ElasticSearch
+
+    ## References
+    - [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/index.html)
+  cwe_id:
+    - 201
+  associated_recipe: Elasticsearch
+  id: python_third_parties_elasticsearch
+  documentation_url: https://docs.bearer.com/reference/rules/python_third_parties_elasticsearch

--- a/tests/python/third_parties/elasticsearch/test.js
+++ b/tests/python/third_parties/elasticsearch/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("elasticsearch", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/third_parties/elasticsearch/testdata/main.py
+++ b/tests/python/third_parties/elasticsearch/testdata/main.py
@@ -1,0 +1,27 @@
+from elasticsearch import Elasticsearch
+
+client = Elasticsearch("https://...", api_key="my_api_key")
+
+# bearer:expected python_third_parties_elasticsearch
+client.update(index="my_index", id="my_doc_id", doc={
+  "name": user.fullname,
+  "email": user.email
+})
+
+# bearer:expected python_third_parties_elasticsearch
+client.update("my_index","my_doc_id", { 
+  "name": user.fullname, 
+  "email": user.email 
+})
+
+# bearer:expected python_third_parties_elasticsearch
+client.index(index="my_index", id="my_doc_id", doc={
+  "name": user.fullname,
+  "email": user.email
+})
+
+
+# ok
+client.index(index="my_index", id="my_doc_id", doc={
+  "user": user.uuid
+})


### PR DESCRIPTION
## Description

Add Python third party rule for Elasticsearch

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
