### PR TITLE
fix: opentelemetry typo

### DIFF
--- a/rules/go/third_parties/open_telemetry.yml
+++ b/rules/go/third_parties/open_telemetry.yml
@@ -107,18 +107,18 @@ auxiliary:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Leakage of sensitive data to Open Telemetry"
+  description: "Leakage of sensitive data to OpenTelemetry"
   remediation_message: |
     ## Description
 
-    Leaking sensitive data to third parties like Open Telemetry is a common cause of data leaks and can lead to data breaches.
+    Leaking sensitive data to third parties like OpenTelemetry is a common cause of data leaks and can lead to data breaches.
 
     ## Remediations
 
-    - **Do** ensure all sensitive data is removed when sending data to third parties like Open Telemetry.
+    - **Do** ensure all sensitive data is removed when sending data to third parties like OpenTelemetry.
 
     ## References
-    - [Open Telemetry Docs](https://opentelemetry.io/docs/)
+    - [OpenTelemetry Docs](https://opentelemetry.io/docs/)
   cwe_id:
     - 201
   id: go_third_parties_open_telemetry

--- a/rules/java/third_parties/open_telemetry.yml
+++ b/rules/java/third_parties/open_telemetry.yml
@@ -23,18 +23,18 @@ languages:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: Leakage of sensitive data to Open Telemetry
+  description: Leakage of sensitive data to OpenTelemetry
   remediation_message: |
     ## Description
 
-    Leaking sensitive data to third parties like Open Telemetry is a common cause of data leaks and can lead to data breaches.
+    Leaking sensitive data to third parties like OpenTelemetry is a common cause of data leaks and can lead to data breaches.
 
     ## Remediations
 
-    - **Do** ensure all sensitive data is removed when sending data to third parties like Open Telemetry.
+    - **Do** ensure all sensitive data is removed when sending data to third parties like OpenTelemetry.
 
     ## References
-    - [Open Telemetry Docs](https://opentelemetry.io/docs/)
+    - [OpenTelemetry Docs](https://opentelemetry.io/docs/)
   cwe_id:
     - 201
   id: java_third_parties_open_telemetry

--- a/rules/javascript/third_parties/open_telemetry.yml
+++ b/rules/javascript/third_parties/open_telemetry.yml
@@ -26,18 +26,18 @@ auxiliary:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Leakage of sensitive data to Open Telemetry"
+  description: "Leakage of sensitive data to OpenTelemetry"
   remediation_message: |
     ## Description
 
-    Leaking sensitive data to third parties like Open Telemetry is a common cause of data leaks and can lead to data breaches.
+    Leaking sensitive data to third parties like OpenTelemetry is a common cause of data leaks and can lead to data breaches.
 
     ## Remediations
 
-    - **Do** ensure all sensitive data is removed when sending data to third parties like Open Telemetry.
+    - **Do** ensure all sensitive data is removed when sending data to third parties like OpenTelemetry.
 
     ## References
-    - [Open Telemetry Docs](https://opentelemetry.io/docs/)
+    - [OpenTelemetry Docs](https://opentelemetry.io/docs/)
   cwe_id:
     - 201
   id: javascript_third_parties_open_telemetry

--- a/rules/php/third_parties/open_telemetry.yml
+++ b/rules/php/third_parties/open_telemetry.yml
@@ -47,18 +47,18 @@ auxiliary:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Leakage of sensitive data to Open Telemetry"
+  description: "Leakage of sensitive data to OpenTelemetry"
   remediation_message: |
     ## Description
 
-    Leaking sensitive data to third parties like Open Telemetry is a common cause of data leaks and can lead to data breaches.
+    Leaking sensitive data to third parties like OpenTelemetry is a common cause of data leaks and can lead to data breaches.
 
     ## Remediations
 
-    - **Do** ensure all sensitive data is removed when sending data to third parties like Open Telemetry.
+    - **Do** ensure all sensitive data is removed when sending data to third parties like OpenTelemetry.
 
     ## References
-    - [Open Telemetry Docs](https://opentelemetry.io/docs/)
+    - [OpenTelemetry Docs](https://opentelemetry.io/docs/)
   cwe_id:
     - 201
   id: php_third_parties_open_telemetry

--- a/rules/ruby/third_parties/open_telemetry.yml
+++ b/rules/ruby/third_parties/open_telemetry.yml
@@ -43,18 +43,18 @@ auxiliary:
 skip_data_types:
   - "Unique Identifier"
 metadata:
-  description: "Leakage of sensitive data to Open Telemetry"
+  description: "Leakage of sensitive data to OpenTelemetry"
   remediation_message: |
     ## Description
 
-    Leaking sensitive data to third parties like Open Telemetry is a common cause of data leaks and can lead to data breaches.
+    Leaking sensitive data to third parties like OpenTelemetry is a common cause of data leaks and can lead to data breaches.
 
     ## Remediations
 
-    - **Do** ensure all sensitive data is removed when sending data to third parties like Open Telemetry.
+    - **Do** ensure all sensitive data is removed when sending data to third parties like OpenTelemetry.
 
     ## References
-    - [Open Telemetry Docs](https://opentelemetry.io/docs/)
+    - [OpenTelemetry Docs](https://opentelemetry.io/docs/)
   cwe_id:
     - 201
   id: ruby_third_parties_open_telemetry


### PR DESCRIPTION
## Description

It's one word not two 🙈 

<img width="1228" alt="Screenshot 2024-06-04 at 11 08 42" src="https://github.com/Bearer/bearer-rules/assets/4560746/a7a9f44b-51d2-4b36-81b2-defb51f72ad0">


<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
