### PR TITLE
feat(python): add OpenTelemetry third party rule (CWE-201)

### DIFF
--- a/rules/python/third_parties/open_telemetry.yml
+++ b/rules/python/third_parties/open_telemetry.yml
@@ -1,0 +1,75 @@
+imports:
+  - python_shared_lang_datatype
+  - python_shared_lang_import2
+patterns:
+  - pattern: |
+      $<SPAN>.$<METHOD>($<...>$<DATA_TYPE>$<...>)
+    filters:
+      - variable: SPAN
+        detection: python_third_parties_open_telemetry_span
+        scope: result
+      - variable: METHOD
+        values:
+          - set_attribute
+          - set_attributes
+          - add_event
+          - add_link
+          - set_status
+          - record_exception
+      - variable: DATA_TYPE
+        detection: python_shared_lang_datatype
+        scope: result
+auxiliary:
+  - id: python_third_parties_open_telemetry_span
+    patterns:
+      - pattern: $<TRACER>.$<METHOD>($<...>)
+        filters:
+          - variable: TRACER
+            detection: python_third_parties_open_telemetry_tracer
+            scope: result
+          - variable: METHOD
+            values:
+              - start_span
+              - get_current_span
+              - use_span
+      - pattern: $<TRACER>.start_as_current_span($<...>) as $<!>$<_>
+        filters:
+          - variable: TRACER
+            detection: python_third_parties_open_telemetry_tracer
+            scope: result
+  - id: python_third_parties_open_telemetry_tracer
+    patterns:
+      - pattern: $<TRACE>($<...>)
+        filters:
+          - variable: TRACE
+            detection: python_shared_lang_import2
+            scope: cursor
+            filters:
+              - variable: MODULE1
+                values: [opentelemetry]
+              - variable: MODULE2
+                values: [trace]
+              - variable: NAME
+                values: [get_tracer]
+languages:
+  - python
+severity: medium
+skip_data_types:
+  - Unique Identifier
+metadata:
+  description: Leakage of sensitive data to OpenTelemetry
+  remediation_message: |
+    ## Description
+
+    Leaking sensitive data to third parties like OpenTelemetry is a common cause of data leaks and can lead to data breaches.
+
+    ## Remediations
+
+    - **Do** ensure all sensitive data is removed when sending data to third parties like OpenTelemetry.
+
+    ## References
+    - [OpenTelemetry Docs](https://opentelemetry.io/docs/)
+  cwe_id:
+    - 201
+  id: python_third_parties_open_telemetry
+  documentation_url: https://docs.bearer.com/reference/rules/python_third_parties_open_telemetry

--- a/tests/python/third_parties/open_telemetry/test.js
+++ b/tests/python/third_parties/open_telemetry/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("open_telemetry", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/third_parties/open_telemetry/testdata/main.py
+++ b/tests/python/third_parties/open_telemetry/testdata/main.py
@@ -1,0 +1,20 @@
+from opentelemetry import trace
+
+def bad():
+  tracer = trace.get_tracer("my-trace.tracer")
+  with tracer.start_as_current_span("my-span") as span:
+    # bearer:expected python_third_parties_open_telemetry
+    span.set_attribute("user", user.email)
+    # bearer:expected python_third_parties_open_telemetry
+    span.add_event("my-event", { "user": user.email })
+    
+  span = tracer.get_current_span()
+  # bearer:expected python_third_parties_open_telemetry
+  span.set_attributes({
+    "user": user.email
+  })
+  
+def ok():
+  tracer = trace.get_tracer("my-trace.tracer")
+  with tracer.start_as_current_span("my-span") as span:
+    span.set_attribute("user", user.uuid)


### PR DESCRIPTION
## Description

Add Python third party rule for OpenTelemetry

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
