### PR TITLE
feat(python): add rollbar third party rule (CWE-201)

### DIFF
--- a/rules/python/third_parties/rollbar.yml
+++ b/rules/python/third_parties/rollbar.yml
@@ -1,0 +1,41 @@
+imports:
+  - python_shared_lang_datatype
+  - python_shared_lang_import1
+patterns:
+  - pattern: |
+      $<ROLLBAR>($<...>$<DATA_TYPE>$<...>)
+    filters:
+      - variable: ROLLBAR
+        detection: python_shared_lang_import1
+        scope: cursor
+        filters:
+          - variable: MODULE1
+            values: [rollbar]
+          - variable: NAME
+            values: [report_message]
+      - variable: DATA_TYPE
+        detection: python_shared_lang_datatype
+        scope: result
+languages:
+  - python
+severity: medium
+skip_data_types:
+  - Unique Identifier
+metadata:
+  description: Leakage of sensitive data to RollBar
+  remediation_message: |
+    ## Description
+
+    Leaking sensitive data to third-party loggers like Rollbar is a common cause of data leaks and can lead to data breaches.
+
+    ## Remediations
+
+    - **Do** ensure all sensitive data is removed when sending data to third-party loggers like Rollbar.
+
+    ## References
+    - [Rollbar docs](https://docs.rollbar.com/docs/python)
+  cwe_id:
+    - 201
+  associated_recipe: Rollbar
+  id: python_third_parties_rollbar
+  documentation_url: https://docs.bearer.com/reference/rules/python_third_parties_rollbar

--- a/tests/python/third_parties/rollbar/test.js
+++ b/tests/python/third_parties/rollbar/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("rollbar", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/third_parties/rollbar/testdata/main.py
+++ b/tests/python/third_parties/rollbar/testdata/main.py
@@ -1,0 +1,14 @@
+# Use  to flag expected findings
+import rollbar
+
+rollbar.init('ACCESS_TOKEN', 'production')
+
+try:
+  # some risky code
+except MyError:
+  # bearer:expected python_third_parties_rollbar
+  rollbar.report_message(f"some weird happened for {user.email}", "info")
+  # ok 
+  rollbar.report_message(f"some weird happened for {user.uuid}", "error")
+except:
+  rollbar.report_exc_info()


### PR DESCRIPTION
## Description

Add Python third party Rollbar rule

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
