### PR TITLE
feat(python): add missing rules from goat project review

### DIFF
--- a/rules/python/django/cookie_missing_http_only.yml
+++ b/rules/python/django/cookie_missing_http_only.yml
@@ -1,0 +1,67 @@
+imports:
+  - python_shared_django_http_response
+  - python_shared_lang_import2
+  - python_shared_lang_instance
+patterns:
+  - pattern: $<SET_COOKIE>
+    filters:
+      - variable: SET_COOKIE
+        detection: python_django_cookie_missing_http_only_set_cookie_call
+        scope: cursor
+      - not:
+          variable: SET_COOKIE
+          detection: python_django_cookie_missing_http_only_set_cookie_http_only
+          scope: cursor
+auxiliary:
+  - id: python_django_cookie_missing_http_only_set_cookie_call
+    patterns:
+      - pattern: $<CALLER>.set_cookie($<...>)
+        filters:
+          - either: 
+            - variable: CALLER
+              detection: python_shared_django_http_response
+              scope: cursor
+            - variable: CALLER
+              detection: python_shared_lang_instance
+              scope: cursor
+              filters:
+                - variable: CLASS
+                  detection: python_shared_lang_import2
+                  scope: cursor
+                  filters:
+                    - variable: MODULE1
+                      values: [django]
+                    - variable: MODULE2
+                      values: [shortcuts]
+                    - variable: NAME
+                      values: [render]
+  - id: python_django_cookie_missing_http_only_set_cookie_http_only
+    patterns:
+      - pattern: $<_>($<...>httponly=$<TRUE>)
+        filters:
+          - variable: "TRUE"
+            detection: python_django_cookie_missing_http_only_true
+            scope: cursor
+  - id: python_django_cookie_missing_http_only_true
+    patterns:
+      - "True"
+languages:
+  - python
+severity: medium
+metadata:
+  description: Missing HTTP Only option in cookie configuration
+  remediation_message: |-
+    ## Description
+
+    Not setting the HTTP Only attribute to "true" in cookie configurations leaves the cookie vulnerable to being accessed by client-side JavaScript. This oversight can lead to the exposure of cookie values, especially on websites susceptible to Cross-Site Scripting (XSS) attacks. Enabling HTTP Only is a critical step in preventing malicious scripts from reading the cookie values through JavaScript.
+
+    ## Remediations
+
+    - **Do** set the HTTP Only attribute to `true` for cookies to prevent them from being accessed by client-side JavaScript. This is a critical step in safeguarding your cookies against unauthorized access, especially in the context of XSS vulnerabilities.
+      ```python
+      response.set_cookie(httponly=True);
+      ```
+  cwe_id:
+    - 1004
+  id: python_django_cookie_missing_http_only
+  documentation_url: https://docs.bearer.com/reference/rules/python_django_cookie_missing_http_only

--- a/rules/python/django/cookie_missing_http_only.yml
+++ b/rules/python/django/cookie_missing_http_only.yml
@@ -17,24 +17,24 @@ auxiliary:
     patterns:
       - pattern: $<CALLER>.set_cookie($<...>)
         filters:
-          - either: 
-            - variable: CALLER
-              detection: python_shared_django_http_response
-              scope: cursor
-            - variable: CALLER
-              detection: python_shared_lang_instance
-              scope: cursor
-              filters:
-                - variable: CLASS
-                  detection: python_shared_lang_import2
-                  scope: cursor
-                  filters:
-                    - variable: MODULE1
-                      values: [django]
-                    - variable: MODULE2
-                      values: [shortcuts]
-                    - variable: NAME
-                      values: [render]
+          - either:
+              - variable: CALLER
+                detection: python_shared_django_http_response
+                scope: cursor
+              - variable: CALLER
+                detection: python_shared_lang_instance
+                scope: cursor
+                filters:
+                  - variable: CLASS
+                    detection: python_shared_lang_import2
+                    scope: cursor
+                    filters:
+                      - variable: MODULE1
+                        values: [django]
+                      - variable: MODULE2
+                        values: [shortcuts]
+                      - variable: NAME
+                        values: [render]
   - id: python_django_cookie_missing_http_only_set_cookie_http_only
     patterns:
       - pattern: $<_>($<...>httponly=$<TRUE>)

--- a/rules/python/django/cookie_missing_http_only.yml
+++ b/rules/python/django/cookie_missing_http_only.yml
@@ -37,7 +37,7 @@ auxiliary:
                         values: [render]
   - id: python_django_cookie_missing_http_only_set_cookie_http_only
     patterns:
-      - pattern: $<_>($<...>httponly=$<TRUE>)
+      - pattern: $<_>($<...>httponly=$<TRUE>$<...>)
         filters:
           - variable: "TRUE"
             detection: python_django_cookie_missing_http_only_true

--- a/rules/python/django/cookie_missing_secure.yml
+++ b/rules/python/django/cookie_missing_secure.yml
@@ -1,0 +1,67 @@
+imports:
+  - python_shared_django_http_response
+  - python_shared_lang_instance
+  - python_shared_lang_import2
+patterns:
+  - pattern: $<SET_COOKIE>
+    filters:
+      - variable: SET_COOKIE
+        detection: python_django_cookie_missing_secure_set_cookie_call
+        scope: cursor
+      - not:
+          variable: SET_COOKIE
+          detection: python_django_cookie_missing_secure_set_cookie_secure
+          scope: cursor
+auxiliary:
+  - id: python_django_cookie_missing_secure_set_cookie_call
+    patterns:
+      - pattern: $<CALLER>.set_cookie($<...>)
+        filters:
+          - either:
+              - variable: CALLER
+                detection: python_shared_django_http_response
+                scope: cursor
+              - variable: CALLER
+                detection: python_shared_lang_instance
+                scope: cursor
+                filters:
+                  - variable: CLASS
+                    detection: python_shared_lang_import2
+                    scope: cursor
+                    filters:
+                      - variable: MODULE1
+                        values: [django]
+                      - variable: MODULE2
+                        values: [shortcuts]
+                      - variable: NAME
+                        values: [render]
+  - id: python_django_cookie_missing_secure_set_cookie_secure
+    patterns:
+      - pattern: $<_>($<...>secure=$<TRUE>)
+        filters:
+          - variable: "TRUE"
+            detection: python_django_cookie_missing_secure_true
+            scope: cursor
+  - id: python_django_cookie_missing_secure_true
+    patterns:
+      - "True"
+languages:
+  - python
+severity: medium
+metadata:
+  description: Missing Secure option in cookie configuration
+  remediation_message: |-
+    ## Description
+
+    Not setting the "Secure" attribute in cookie configuration can lead to unauthorized third-party access. This attribute, when enabled, ensures cookies are sent to the server only over HTTPS, enhancing security by preventing potential eavesdropping.
+
+    ## Remediations
+
+    - **Do** set the `secure` attribute to `true` to enforce the transmission of cookies over HTTPS only.
+      ```python
+      response.set_cookie(secure=True)
+      ```
+  cwe_id:
+    - 614
+  id: python_django_cookie_missing_secure
+  documentation_url: https://docs.bearer.com/reference/rules/python_django_cookie_missing_secure

--- a/rules/python/django/crlf_injection.yml
+++ b/rules/python/django/crlf_injection.yml
@@ -1,0 +1,51 @@
+imports:
+  - python_shared_common_user_input
+patterns:
+  - pattern: |
+      $<FILE>.write($<USER_INPUT>$<...>)
+    filters:
+      - variable: FILE
+        detection: python_django_crlf_injection_file
+        scope: cursor
+      - variable: USER_INPUT
+        detection: python_shared_common_user_input
+        scope: result
+      - not:
+          variable: USER_INPUT
+          detection: python_django_crlf_injection_sanitized_dynamic_input
+          scope: result
+auxiliary:
+  - id: python_django_crlf_injection_file
+    patterns:
+      - open($<...>)
+  - id: python_django_crlf_injection_sanitized_dynamic_input
+    patterns:
+      - $<_>.strip()
+      - pattern: $<_>.strip($<SOURCE>)
+        filters:
+          - variable: SOURCE
+            string_regex: \A(\\r\\n|\\n\\r)n\z
+languages:
+  - python
+severity: medium
+metadata:
+  description: Possible CLRF injection detected
+  remediation_message: |-
+    ## Description
+
+    CRLF (Carriage Return Line Feed) injection vulnerability occurs when an attacker is able to insert a sequence of line termination characters into a log message or a file. This can lead to forged log entries, compromising the integrity of log files, or worse, a denial-of-service (DoS) if an attacker abuses the vulnerability by using up all available disk space. 
+
+    ## Remediations
+
+    - **Do** strip any carriage return and line feed characters from user input data before logging it or writing to a file. This prevents attackers from injecting malicious CRLF sequences.
+      ```pyhton
+      response.write(user_input.replaceAll("[\r\n]+", ""));
+      ```
+
+    ## References
+
+    - [OWASP CRLF Injection](https://owasp.org/www-community/vulnerabilities/CRLF_Injection)
+  cwe_id:
+    - 93
+  id: python_django_crlf_injection
+  documentation_url: https://docs.bearer.com/reference/rules/python_django_crlf_injection

--- a/rules/python/django/csrf_protection_disabled.yml
+++ b/rules/python/django/csrf_protection_disabled.yml
@@ -1,0 +1,32 @@
+imports:
+  - python_shared_lang_import4
+patterns:
+  - pattern: $<CSRF_EXEMPT>
+    filters:
+      - variable: CSRF_EXEMPT
+        regex: \A@(django\.)?(views\.)?(decorators\.)?(csrf\.)?csrf_exempt\z
+languages:
+  - python
+severity: medium
+metadata:
+  description: Missing Cross-Site Request Forgery (CSRF) token(s)
+  remediation_message: |-
+    ## Description
+
+    In a Django application, using `@csrf_exempt` to disable CSRF (Cross-Site Request Forgery) protection can introduce increased security risks. CSRF is a forgery attack that tricks authenticated users into executing unintended actions on the website, potentially compromising security or data integrity of your application.
+
+    ## Remediations
+
+    - **Do not** mark Djanog routes as CSRF exempt
+      ```python
+      @csrf_exempt # unsafe
+      def my_risky_route():
+      ```
+
+    ## References
+
+    - [Django CSRF protection](https://docs.djangoproject.com/en/5.0/ref/csrf/)
+  cwe_id:
+    - 352
+  id: python_django_csrf_protection_disabled
+  documentation_url: https://docs.bearer.com/reference/rules/python_django_csrf_protection_disabled

--- a/rules/python/lang/deserialization_of_user_input.yml
+++ b/rules/python/lang/deserialization_of_user_input.yml
@@ -18,6 +18,8 @@ patterns:
             values:
               - load
               - loads
+              - dump
+              - dumps
       - variable: USER_INPUT
         detection: python_shared_common_user_input
         scope: result

--- a/rules/python/lang/weak_password_encryption_md5.yml
+++ b/rules/python/lang/weak_password_encryption_md5.yml
@@ -1,29 +1,74 @@
 imports:
   - python_shared_lang_datatype
+  - python_shared_lang_import1
 patterns:
-  - pattern: hashlib.md5($<OPTIONAL_DATA_TYPE>)
+  - pattern: $<FUNCTION>($<ALGORITHM>, $<PASSWORD>$<...>)
     filters:
-      - variable: OPTIONAL_DATA_TYPE
+      - variable: FUNCTION
+        detection: python_shared_lang_import1
+        scope: cursor
+        filters:
+          - variable: MODULE1
+            values: [hashlib]
+          - variable: NAME
+            values: [new]
+      - variable: ALGORITHM
+        string_regex: (?i)\Amd\d
+      - variable: PASSWORD
         detection: python_shared_lang_datatype
         scope: result
-  - pattern: $<MD5_INIT>.update($<OPTIONAL_DATA_TYPE>)
+  - pattern: $<FUNCTION>($<PASSWORD>$<...>)
     filters:
-      - variable: MD5_INIT
+      - variable: FUNCTION
+        detection: python_shared_lang_import1
+        scope: cursor
+        filters:
+          - variable: MODULE1
+            values: [hashlib]
+          - variable: NAME
+            values: [md5]
+      - variable: PASSWORD
+        detection: python_shared_lang_datatype
+        scope: result
+  - pattern: $<MD_INIT>.update($<PASSWORD>)
+    filters:
+      - variable: MD_INIT
         detection: python_lang_weak_hash_md5_init
         scope: cursor
-      - variable: OPTIONAL_DATA_TYPE
+      - variable: PASSWORD
         detection: python_shared_lang_datatype
         scope: result
 auxiliary:
   - id: python_lang_weak_hash_md5_init
     patterns:
-      - hashlib.md5()
+      - pattern: $<FUNCTION>($<...>)
+        filters:
+          - variable: FUNCTION
+            detection: python_shared_lang_import1
+            scope: cursor
+            filters:
+              - variable: MODULE1
+                values: [hashlib]
+              - variable: NAME
+                values: [md5]
+      - pattern: $<FUNCTION>($<ALGORITHM>$<...>)
+        filters:
+          - variable: FUNCTION
+            detection: python_shared_lang_import1
+            scope: cursor
+            filters:
+              - variable: MODULE1
+                values: [hashlib]
+              - variable: NAME
+                values: [new]
+          - variable: ALGORITHM
+            string_regex: (?i)\Amd\d
 languages:
   - python
 only_data_types:
-  - "Passwords"
+  - Passwords
 metadata:
-  description: "Usage of weak hashing library on a password (MD5)"
+  description: Usage of weak hashing library on a password (MD5)
   remediation_message: |-
     ## Description
 

--- a/rules/python/lang/weak_password_encryption_sha1.yml
+++ b/rules/python/lang/weak_password_encryption_sha1.yml
@@ -1,29 +1,73 @@
 imports:
   - python_shared_lang_datatype
 patterns:
-  - pattern: hashlib.sha1($<OPTIONAL_DATA_TYPE>)
+  - pattern: $<FUNCTION>($<ALGORITHM>, $<PASSWORD>$<...>)
     filters:
-      - variable: OPTIONAL_DATA_TYPE
+      - variable: FUNCTION
+        detection: python_shared_lang_import1
+        scope: cursor
+        filters:
+          - variable: MODULE1
+            values: [hashlib]
+          - variable: NAME
+            values: [new]
+      - variable: ALGORITHM
+        string_regex: (?i)\Asha1?\z
+      - variable: PASSWORD
         detection: python_shared_lang_datatype
         scope: result
-  - pattern: $<SHA1_INIT>.update($<OPTIONAL_DATA_TYPE>)
+  - pattern: $<FUNCTION>($<PASSWORD>)
+    filters:
+      - variable: FUNCTION
+        detection: python_shared_lang_import1
+        scope: cursor
+        filters:
+          - variable: MODULE1
+            values: [hashlib]
+          - variable: NAME
+            values: [sha1]
+      - variable: PASSWORD
+        detection: python_shared_lang_datatype
+        scope: result
+  - pattern: $<SHA1_INIT>.update($<PASSWORD>)
     filters:
       - variable: SHA1_INIT
         detection: python_lang_weak_hash_sha1_init
         scope: cursor
-      - variable: OPTIONAL_DATA_TYPE
+      - variable: PASSWORD
         detection: python_shared_lang_datatype
         scope: result
 auxiliary:
   - id: python_lang_weak_hash_sha1_init
     patterns:
-      - hashlib.sha1()
+      - pattern: $<FUNCTION>($<...>)
+        filters:
+          - variable: FUNCTION
+            detection: python_shared_lang_import1
+            scope: cursor
+            filters:
+              - variable: MODULE1
+                values: [hashlib]
+              - variable: NAME
+                values: [sha1]
+      - pattern: $<FUNCTION>($<ALGORITHM>$<...>)
+        filters:
+          - variable: FUNCTION
+            detection: python_shared_lang_import1
+            scope: cursor
+            filters:
+              - variable: MODULE1
+                values: [hashlib]
+              - variable: NAME
+                values: [new]
+          - variable: ALGORITHM
+            string_regex: (?i)\Asha1?\z
 languages:
   - python
 only_data_types:
-  - "Passwords"
+  - Passwords
 metadata:
-  description: "Usage of weak hashing library on a password (SHA-1)"
+  description: Usage of weak hashing library on a password (SHA-1)
   remediation_message: |-
     ## Description
 

--- a/rules/python/lang/weak_password_encryption_sha1.yml
+++ b/rules/python/lang/weak_password_encryption_sha1.yml
@@ -1,5 +1,6 @@
 imports:
   - python_shared_lang_datatype
+  - python_shared_lang_import1
 patterns:
   - pattern: $<FUNCTION>($<ALGORITHM>, $<PASSWORD>$<...>)
     filters:

--- a/rules/python/lang/xml_external_entity_vulnerability.yml
+++ b/rules/python/lang/xml_external_entity_vulnerability.yml
@@ -1,0 +1,68 @@
+imports:
+  - python_shared_common_external_input
+  - python_shared_lang_instance
+  - python_shared_lang_import2
+  - python_shared_lang_import3
+patterns:
+  - pattern: |
+      $<XML_SAX>($<EXTERNAL_INPUT>$<...>)
+    filters:
+      - variable: XML_SAX
+        detection: python_shared_lang_import2
+        scope: cursor
+        filters:
+          - variable: MODULE1
+            values: [xml]
+          - variable: MODULE2
+            values: [sax]
+          - variable: NAME
+            values:
+              - parse
+              - parseString
+      - variable: EXTERNAL_INPUT
+        detection: python_shared_common_external_input
+        scope: result
+  - pattern: |
+      $<PULLDOM>($<EXTERNAL_INPUT>$<...>)
+    filters:
+      - variable: PULLDOM
+        detection: python_shared_lang_import3
+        scope: cursor
+        filters:
+          - variable: MODULE1
+            values: [xml]
+          - variable: MODULE2
+            values: [dom]
+          - variable: MODULE3
+            values: [pulldom]
+          - variable: NAME
+            values:
+              - parse
+              - parseString
+      - variable: EXTERNAL_INPUT
+        detection: python_shared_common_external_input
+        scope: result
+languages:
+  - python
+severity: medium
+metadata:
+  description: Usage of vulnerable XML libraries
+  remediation_message: |-
+    ## Description
+
+    Certain XML parsers - like xml.sax and pulldom - are known to be vulnerable to XML parsing attacks such as Billion Laughs (exponential entity expansion). These parsers should be avoided. Avoid such vulnerable libraries, and as an additional precaution, use something like defusedxml to further mitigate XML vulnerabilities in Python.   
+
+    ## Remediations
+
+    - **Do not** use XML parsers that are known to be vulnerable to external entity attacks.
+    - **Do** exercise caution when parsing XML and always ensure parser input is sufficiently validated and sanitized.
+
+    ## References
+
+    - [Python XML parsers and their vulnerabilities](https://docs.python.org/3/library/xml.html#xml-vulnerabilities)
+    - [The defusexml package](https://pypi.org/project/defusedxml/)
+    - [OWASP XML External Entity (XXE) prevention cheat sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#python)
+  cwe_id:
+    - 611
+  id: python_lang_xml_external_entity_vulnerability
+  documentation_url: https://docs.bearer.com/reference/rules/python_lang_xml_external_entity_vulnerability

--- a/rules/python/shared/django/http_response.yml
+++ b/rules/python/shared/django/http_response.yml
@@ -21,6 +21,10 @@ patterns:
                 values: [http]
               - variable: NAME
                 values: [HttpResponse]
+  # fallback
+  - response
+  - res
+  - r
 metadata:
   description: "Python Django HTTP Response instance."
   id: python_shared_django_http_response

--- a/rules/python/shared/lang/dynamic_input.yml
+++ b/rules/python/shared/lang/dynamic_input.yml
@@ -20,6 +20,11 @@ patterns:
             values: [getopt]
           - variable: NAME
             values: [getopt]
+  - pattern: $<DYNAMIC_INPUT>;
+    filters:
+      - variable: DYNAMIC_INPUT
+        detection: python_shared_lang_dynamic_input_input
+        scope: cursor_strict
 auxiliary:
   - id: python_shared_lang_dynamic_input_parser
     patterns:
@@ -33,6 +38,10 @@ auxiliary:
                 values: [argparse]
               - variable: NAME
                 values: [ArgumentParser]
+  - id: python_shared_lang_dynamic_input_input
+    patterns:
+      - |
+        def $<_>($<...>$<!>$<ARG>$<...>):
 metadata:
   description: "Python dynamic input."
   id: python_shared_lang_dynamic_input

--- a/rules/python/shared/lang/dynamic_input.yml
+++ b/rules/python/shared/lang/dynamic_input.yml
@@ -42,6 +42,8 @@ auxiliary:
     patterns:
       - |
         def $<_>($<...>$<!>$<ARG>$<...>):
+      - |
+        def $<_>($<...>$<!>$<ARG>=$<_>$<...>):
 metadata:
   description: "Python dynamic input."
   id: python_shared_lang_dynamic_input

--- a/tests/python/django/cookie_missing_http_only/test.js
+++ b/tests/python/django/cookie_missing_http_only/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("cookie_missing_http_only", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/django/cookie_missing_http_only/testdata/main.py
+++ b/tests/python/django/cookie_missing_http_only/testdata/main.py
@@ -1,0 +1,9 @@
+def bad(request):
+  cookie = jwt.encode(payload, 'csrf_vulneribility', algorithm='HS256')
+  # bearer:expected python_django_cookie_missing_http_only
+  response.set_cookie('auth_cookie', cookie)
+  
+def ok(request):
+  cookie = jwt.encode(payload, 'csrf_vulneribility', algorithm='HS256')
+  # ok
+  response.set_cookie('auth_cookie', cookie, httponly=True)

--- a/tests/python/django/cookie_missing_secure/test.js
+++ b/tests/python/django/cookie_missing_secure/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("cookie_missing_secure", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/django/cookie_missing_secure/testdata/main.py
+++ b/tests/python/django/cookie_missing_secure/testdata/main.py
@@ -1,0 +1,9 @@
+def bad(request):
+  cookie = jwt.encode(payload, 'csrf_vulneribility', algorithm='HS256')
+  # bearer:expected python_django_cookie_missing_secure
+  response.set_cookie('auth_cookie', cookie)
+  
+def ok(request):
+  cookie = jwt.encode(payload, 'csrf_vulneribility', algorithm='HS256')
+  # ok
+  response.set_cookie('auth_cookie', cookie, secure=True)

--- a/tests/python/django/crlf_injection/test.js
+++ b/tests/python/django/crlf_injection/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("crlf_injection", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/django/crlf_injection/testdata/main.py
+++ b/tests/python/django/crlf_injection/testdata/main.py
@@ -1,0 +1,17 @@
+def bad(request):
+  log_code = request.POST.get('log_code')
+  log_filename = os.path.join(dirname, "my-log-code.py")
+  f = open(log_filename,"w")
+  # bearer:expected python_django_crlf_injection
+  f.write(log_code)
+  f.close()
+  
+def ok(request):
+  log_code = request.POST.get('log_code')
+  log_filename = os.path.join(dirname, "my-log-code.py")
+  f = open(log_filename,"w")
+  # ok
+  f.write(log_code.strip())
+  # ok
+  f.write(log_code.strip("\r\n"))
+  f.close()

--- a/tests/python/django/csrf_protection_disabled/test.js
+++ b/tests/python/django/csrf_protection_disabled/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("csrf_protection_disabled", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/django/csrf_protection_disabled/testdata/main.py
+++ b/tests/python/django/csrf_protection_disabled/testdata/main.py
@@ -1,0 +1,9 @@
+from django.views.decorators.csrf import csrf_exempt
+
+# bearer:expected python_django_csrf_protection_disabled
+@csrf_exempt
+def my_unsafe_route():
+  # some route
+ 
+def my_safe_route():
+  # some safe route

--- a/tests/python/lang/weak_password_encryption_md5/testdata/bad.py
+++ b/tests/python/lang/weak_password_encryption_md5/testdata/bad.py
@@ -13,3 +13,7 @@ password = user.password
 # bearer:expected python_lang_weak_password_encryption_md5
 result = hashlib.md5(password.encode())
 result.hexdigest()
+
+from hashlib import md5
+# bearer:expected python_lang_weak_password_encryption_md5
+result = md5(password.encode()).hexdigest()

--- a/tests/python/lang/xml_external_entity_vulnerability/test.js
+++ b/tests/python/lang/xml_external_entity_vulnerability/test.js
@@ -1,0 +1,20 @@
+const {
+  createNewInvoker,
+  getEnvironment,
+} = require("../../../helper.js")
+const { ruleId, ruleFile, testBase } = getEnvironment(__dirname)
+
+describe(ruleId, () => {
+  const invoke = createNewInvoker(ruleId, ruleFile, testBase)
+
+  test("xml_external_entity_vulnerability", () => {
+    const testCase = "main.py"
+
+    const results = invoke(testCase)
+
+    expect(results).toEqual({
+      Missing: [],
+      Extra: []
+    })
+  })
+})

--- a/tests/python/lang/xml_external_entity_vulnerability/testdata/main.py
+++ b/tests/python/lang/xml_external_entity_vulnerability/testdata/main.py
@@ -8,9 +8,13 @@ def bad(some_input):
   # bearer:expected python_lang_xml_external_entity_vulnerability
   parse(some_input)
 
-def bad2(some_input):
+def bad2(request):
   # bearer:expected python_lang_xml_external_entity_vulnerability
   parseString(request.body.decode('utf-8'), parser=parser)
+  
+def bad3(some_keyword_input="default"):
+  # bearer:expected python_lang_xml_external_entity_vulnerability
+  parseString(some_keyword_input, parser=parser)
   
 def ok():
   sax.parse("known string")

--- a/tests/python/lang/xml_external_entity_vulnerability/testdata/main.py
+++ b/tests/python/lang/xml_external_entity_vulnerability/testdata/main.py
@@ -1,0 +1,16 @@
+# Use bearer:expected python_lang_xml_external_entity_vulnerability to flag expected findings
+from xml import sax
+from xml.dom.pulldom import parse, parseString
+
+def bad(some_input):
+  # bearer:expected python_lang_xml_external_entity_vulnerability
+  sax.parse(some_input)
+  # bearer:expected python_lang_xml_external_entity_vulnerability
+  parse(some_input)
+
+def bad2(some_input):
+  # bearer:expected python_lang_xml_external_entity_vulnerability
+  parseString(request.body.decode('utf-8'), parser=parser)
+  
+def ok():
+  sax.parse("known string")


### PR DESCRIPTION
## Description

Add missing rules
* Django cookies missing secure settings
* Django CSRF exempt usage
* Django CRLF sanitization
* Python XXE 

Extend existing rules
* Django HTTP response object
* Dynamic input to include vars passed to functions
* Add missing pickle methods to eserialization rule
* Fix password hashing rules so that they use correct import helpers

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
