### PR TITLE
fix(python): incorrect severity for XXE rule

### DIFF
--- a/rules/python/lang/xml_external_entity_vulnerability.yml
+++ b/rules/python/lang/xml_external_entity_vulnerability.yml
@@ -44,7 +44,7 @@ patterns:
         scope: result
 languages:
   - python
-severity: medium
+severity: critical
 metadata:
   description: Usage of vulnerable XML libraries
   remediation_message: |-


### PR DESCRIPTION
## Description

To be consistent with the XXE rules in other languages, CWE-611 should be critical severity 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
