### PR TITLE
fix: typos in ClickHouse rules

### DIFF
--- a/rules/java/third_parties/clickhouse.yml
+++ b/rules/java/third_parties/clickhouse.yml
@@ -110,7 +110,7 @@ metadata:
 
     ## Remediations
 
-    - **Do** ensure all sensitive data is removed when sending data to third-party services like Algolia.
+    - **Do** ensure all sensitive data is removed when sending data to third-party services like ClickHouse.
 
     ## References
     - [ClickHouse docs](https://clickhouse.com/docs/en/intro/)

--- a/rules/php/third_parties/clickhouse.yml
+++ b/rules/php/third_parties/clickhouse.yml
@@ -27,7 +27,7 @@ metadata:
 
     ## Remediations
 
-    - **Do** ensure all sensitive data is removed when sending data to third-party services like Algolia.
+    - **Do** ensure all sensitive data is removed when sending data to third-party services like ClickHouse.
 
     ## References
     - [ClickHouse docs](https://clickhouse.com/docs/en/intro/)


### PR DESCRIPTION
## Description

Java and PHP have the same copy-pasta typo that Ruby had 🙈 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
