### PR TITLE
fix(golang): permissive regex rule for validation purposes

### DIFF
--- a/rules/go/lang/permissive_regex_validation.yml
+++ b/rules/go/lang/permissive_regex_validation.yml
@@ -1,17 +1,26 @@
 patterns:
-  - pattern: |
-      $<REGEXP>.$<METHOD>($<PATTERN>$<...>)
+  - pattern: $<PERMISSIVE_REGEXP>.$<METHOD>($<...>)
     filters:
-      - variable: REGEXP
-        detection: go_lang_permissive_regex_validation_regexp
+      - variable: PERMISSIVE_REGEXP
+        detection: go_lang_permissive_regex_validation_permissive_regexp
       - variable: METHOD
         values:
-          - Compile
-          - MustCompile
-      - not:
-          variable: PATTERN
-          string_regex: \A.\\A.*\\[zZ].\z
+          - Match
+          - MatchString
 auxiliary:
+  - id: go_lang_permissive_regex_validation_permissive_regexp
+    patterns:
+      - pattern: $<REGEXP>.$<METHOD>($<PATTERN>$<...>)
+        filters:
+          - variable: REGEXP
+            detection: go_lang_permissive_regex_validation_regexp
+          - variable: METHOD
+            values:
+              - Compile
+              - MustCompile
+          - not:
+              variable: PATTERN
+              string_regex: \A.\\A.*\\[zZ].\z
   - id: go_lang_permissive_regex_validation_regexp
     patterns:
       - import $<!>"regexp"
@@ -22,15 +31,15 @@ auxiliary:
 languages:
   - go
 metadata:
-  description: "Missing validation for regular expression"
+  description: Permissive regular expression used in matching
   remediation_message: |-
     ## Description
 
-    When using regular expressions for validation, it's crucial to specify the start and end of the text boundaries. This ensures the entire text is validated, not just parts of it. Use \A and \z (or \Z) over ^ and $ to specify text boundaries, because these accurately mark the beginning and end of the text, even in multiline mode.
+    When matching with regular expressions -- especially for validation purposes -- it is crucial to specify the start and end of the text boundaries. This ensures the entire text is validated, not just parts of it, and prevents attackers from bypassing validation with partially matching input. Use \A and \z (or \Z) over ^ and $ to specify text boundaries, because these accurately mark the beginning and end of the text, even in multiline mode.
 
     ## Remediations
 
-    - **Do not** use regular expressions without specifying start and end boundaries. This can lead to incomplete validation.
+    - **Do not** use regular expressions for validation without specifying start and end boundaries. This can lead to partial matches being considered valid, when they may contain unsafe input.
       ```go
       regexp.MustCompile("foo") // unsafe
       ```

--- a/tests/go/lang/permissive_regex_validation/testdata/main.go
+++ b/tests/go/lang/permissive_regex_validation/testdata/main.go
@@ -5,11 +5,23 @@ import (
 	"regexp"
 )
 
-func bad() {
+func permissiveRegex(input string) {
+	re := regexp.MustCompile("[a-zA-Z0-9]*")
+
+	// likely not validation - we ignore this
+	re.ReplaceAllString(input, "foo")
+
 	// bearer:expected go_lang_permissive_regex_validation
-	_ = regexp.MustCompile("[a-zA-Z0-9]*")
+	re.Match([]byte(input))
+	// bearer:expected go_lang_permissive_regex_validation
+	re.MatchString(input)
 }
 
-func good() {
-	_ = regexp.MustCompile(`\A[a-zA-Z0-9]*\z`)
+func goodRegexp(input string) {
+	re := regexp.MustCompile(`\A[a-zA-Z0-9]*\z`)
+	if re.MatchString(input) {
+		// continue with valid string
+	} else {
+		// handle invalid string
+	}
 }


### PR DESCRIPTION
## Description

Ideally the `go_lang_permissive_regex_validation` rule would only trigger when the permissive regular expression is being used for validation-specific purposes. Unlike some frameworks (Ruby-on-Rails, PHP Symfony), with golang, we cannot determine how a particular regular expression is being used. For this reason, the rule was triggering on the compilation of permissive regex, rather than its use. However, this meant that we were seeing some confusing false positives with this rule -- for example, with `Replace` (where there is no real security issue).

To address this, we modify the rule so that it triggers only when a permissive regular expression is used with `Match` methods, as this is more likely to be a validation case. We hope that this will reduce the rate of false positives while still proving useful in alerting users to actual security issues. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
