### PR TITLE
fix: use more appropriate cwe for file permission rules

### DIFF
--- a/rules/go/gosec/file_permissions/file_perm.yml
+++ b/rules/go/gosec/file_permissions/file_perm.yml
@@ -48,7 +48,7 @@ metadata:
     - **Do** regularly review and audit file permissions in your system to ensure they adhere to the principle of least privilege, minimizing the access level to what is strictly necessary for operational functionality.
 
   cwe_id:
-    - 276
+    - 732
   id: go_gosec_file_permissions_file_perm
   documentation_url: https://docs.bearer.com/reference/rules/go_gosec_file_permissions_file_perm
 severity: high

--- a/rules/go/gosec/file_permissions/mkdir.yml
+++ b/rules/go/gosec/file_permissions/mkdir.yml
@@ -42,7 +42,7 @@ metadata:
     - **Do** regularly review and audit file permissions in your system to ensure they adhere to the principle of least privilege, minimizing the access level to what is strictly necessary for operational functionality.
 
   cwe_id:
-    - 276
+    - 732
   id: go_gosec_file_permissions_mkdir
   documentation_url: https://docs.bearer.com/reference/rules/go_gosec_file_permissions_mkdir
 severity: high

--- a/rules/go/gosec/filesystem/poor_write_permissions.yml
+++ b/rules/go/gosec/filesystem/poor_write_permissions.yml
@@ -41,7 +41,7 @@ metadata:
     - [Linux 'chmod' Command](https://linux.die.net/man/1/chmod)
     - [OWASP File Handling Best Practices](https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html)
   cwe_id:
-    - 276
+    - 732
   id: go_gosec_filesystem_poor_write_permissions
   documentation_url: https://docs.bearer.com/reference/rules/go_gosec_filesystem_poor_write_permissions
 severity: high

--- a/rules/java/android/world_readable_writable_mode.yml
+++ b/rules/java/android/world_readable_writable_mode.yml
@@ -31,7 +31,7 @@ metadata:
     - [Android Context.MODE_PRIVATE reference](https://developer.android.com/reference/android/content/Context#MODE_PRIVATE)
     - [Android Content Provider reference](https://developer.android.com/reference/android/content/ContentProvider)
   cwe_id:
-    - 276
+    - 732
   id: java_android_world_readable_writable_mode
   documentation_url: https://docs.bearer.com/reference/rules/java_android_world_readable_writable_mode
 severity: high

--- a/rules/javascript/lang/file_permissions.yml
+++ b/rules/javascript/lang/file_permissions.yml
@@ -55,6 +55,6 @@ metadata:
     - **Do** prefer assigning file permissions to 'groups' rather than 'other' when you need to extend privileges to users who are not the owners. This approach helps in limiting access to a more controlled set of users.
 
   cwe_id:
-    - 276
+    - 732
   id: javascript_lang_file_permissions
   documentation_url: https://docs.bearer.com/reference/rules/javascript_lang_file_permissions

--- a/rules/python/django/file_permissions.yml
+++ b/rules/python/django/file_permissions.yml
@@ -62,6 +62,6 @@ metadata:
         FILE_UPLOAD_PERMISSIONS = 0o600
       ```
   cwe_id:
-    - 276
+    - 732
   id: python_django_file_permissions
   documentation_url: https://docs.bearer.com/reference/rules/python_django_file_permissions

--- a/rules/python/lang/file_permissions.yml
+++ b/rules/python/lang/file_permissions.yml
@@ -115,6 +115,6 @@ metadata:
       os.umask(0) # unsafe
     ```
   cwe_id:
-    - 276
+    - 732
   id: python_lang_file_permissions
   documentation_url: https://docs.bearer.com/reference/rules/python_lang_file_permissions


### PR DESCRIPTION
## Description
<!-- What does this PR do and how does it -->

Replace CWE-276: Incorrect Default Permissions:
> During installation, installed file permissions are set to allow anyone to modify those files. 

with CWE-732: Incorrect Permission Assignment for Critical Resource:
> The product specifies permissions for a security-critical resource in a way that allows that resource to be read or modified by unintended actors. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
