### PR TITLE
fix(golang): remove encoder pattern from deserialization rule (CWE-502)

### DIFF
--- a/rules/go/lang/deserialization_of_user_input.yml
+++ b/rules/go/lang/deserialization_of_user_input.yml
@@ -5,20 +5,10 @@ patterns:
     filters:
       - variable: DECODER
         detection: go_lang_deserialization_of_user_input_decoder
-  - pattern: $<ENCODER>.Encode($<...>);
-    filters:
-      - variable: ENCODER
-        detection: go_lang_deserialization_of_user_input_encoder
 auxiliary:
   - id: go_lang_deserialization_of_user_input_decoder
     patterns:
       - pattern: gob.NewDecoder($<USER_INPUT>);
-        filters:
-          - variable: USER_INPUT
-            detection: go_shared_lang_dynamic_input_combined
-  - id: go_lang_deserialization_of_user_input_encoder
-    patterns:
-      - pattern: gob.NewEncoder($<USER_INPUT>);
         filters:
           - variable: USER_INPUT
             detection: go_shared_lang_dynamic_input_combined


### PR DESCRIPTION
## Description

Encoding user input isn't itself unsafe until this input is decoded. We therefore remove the serialization case to keep consistent with our other CWE-502 rules which are directly concerned with the deserialization of user input. 

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
