### PR TITLE
fix(javascript): handle mysql pool as a promise

### DIFF
--- a/rules/javascript/lang/sql_injection.yml
+++ b/rules/javascript/lang/sql_injection.yml
@@ -113,6 +113,10 @@ auxiliary:
   - id: javascript_lang_sql_injection_mysql_pool
     patterns:
       - mysql.createPool()
+      - pattern: $<MYSQL_POOL>.promise()
+        filters:
+          - variable: MYSQL_POOL
+            detection: javascript_lang_sql_injection_mysql_pool
   - id: javascript_lang_sql_injection_pool_conn
     patterns:
       - pattern: $<MYSQL_POOL>.getConnection(function($<_>, $<!>$<_>) {})

--- a/tests/javascript/lang/sql_injection/testdata/mysql2_sql_injection.js
+++ b/tests/javascript/lang/sql_injection/testdata/mysql2_sql_injection.js
@@ -2,31 +2,62 @@ const connection = mysql.createConnection({});
 const asyncConn = await mysql.createConnection({});
 
 module.exports.asyncFooBar = async function (req, res) {
-	// bearer:expected javascript_lang_sql_injection
-	await asyncConn.execute(
-		"SELECT * FROM `admin_users` WHERE ID = " + req.admin.id
-	);
-	res.send("ok");
+  // bearer:expected javascript_lang_sql_injection
+  await asyncConn.execute(
+    "SELECT * FROM `admin_users` WHERE ID = " + req.admin.id
+  );
+  res.send("ok");
 };
 
 module.exports.fooBar = function (req, _res) {
-// bearer:expected javascript_lang_sql_injection
-	connection.query(
-		"SELECT * FROM `user` WHERE name = " + req.params.customer.name
-	);
+  // bearer:expected javascript_lang_sql_injection
+  connection.query(
+    "SELECT * FROM `user` WHERE name = " + req.params.customer.name
+  );
 
-	// pool query
-	var pool = mysql.createPool();
-// bearer:expected javascript_lang_sql_injection
-	pool.query(
-		"SELECT * FROM users WHERE name = " + req.params.user_name,
-		function () {}
-	);
-	pool.getConnection(function (_err, conn) {
-// bearer:expected javascript_lang_sql_injection
-		conn.query("SELECT * FROM users WHERE name = " + req.params.user_name, function () {});
-		pool.releaseConnection(conn);
-	});
+  // pool query
+  var pool = mysql.createPool();
+  // bearer:expected javascript_lang_sql_injection
+  pool.query(
+    "SELECT * FROM users WHERE name = " + req.params.user_name,
+    function () {}
+  );
+  pool.getConnection(function (_err, conn) {
+    // bearer:expected javascript_lang_sql_injection
+    conn.query(
+      "SELECT * FROM users WHERE name = " + req.params.user_name,
+      function () {}
+    );
+    pool.releaseConnection(conn);
+  });
 
-	res.send("ok");
+  res.send("ok");
+};
+
+module.exports.asyncPool = async function (req, _res) {
+  // pool query
+  var pool = mysql.createPool({
+    host: "mysql",
+    user: "root",
+    password: "password",
+    database: "testdb",
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 0,
+  });
+  // promisify pool
+  const poolPromise = pool.promise();
+  var userName = req.query.name;
+  // bearer:expected javascript_lang_sql_injection
+  await poolPromise.query(`SELECT * FROM users WHERE name = '${userName}'`);
+  poolPromise.getConnection(function (_err, conn) {
+    // bearer:expected javascript_lang_sql_injection
+    conn.query(
+      `SELECT * FROM users WHERE name = '${userName}'`,
+      function () {}
+    );
+    poolPromise.releaseConnection(conn);
+  });
+
+  res.send("ok");
 };


### PR DESCRIPTION
## Description

If we make a promise from a MySQL pool instance, the SQL injection rule loses track of any injection cases happening with this now-async pool instance. 

An alternative would be to consider the `promise()` method a "reflexive" method in the engine, but I didn't go this route for two reasons: (a.) it's not a true reflexive method (`x.promise()` is strictly not the same as `x`) and (b.) this would require an additional scope change to the SQL injection rule (from cursor to result) which again suggests to me that it's not the way to go.

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
