### PR TITLE
fix: typo in golang guidelines

### DIFF
--- a/rules/go/lang/cross_site_scripting.yml
+++ b/rules/go/lang/cross_site_scripting.yml
@@ -36,7 +36,7 @@ metadata:
     ## Remediations
 
     - **Do not** include user input directly in a response. This practice can lead to XSS vulnerabilities.
-    ```golang
+    ```go
       func bad(w http.ResponseWriter, r *http.Request) {
         userInput := r.URL.Query().Get("input")
         fmt.Fprintf(w, "<html><body>%s</body></html>", userInput)


### PR DESCRIPTION
## Description

`go` not `golang` -- typo means documentation cannot build

<!-- Add this section if required
## Related
-->
<!-- Closes some existing issue
- Close #AAA
<!-- References some existing PR
- #CCC
-->

## Checklist
If this is your first time contributing please [sign the CLA](https://docs.bearer.com/contributing/)

- [ ] My rule has adequate metadata to explain its use.
