### PR TITLE
docs(rules): add safe examples to javascript_lang_logger_leak

### DIFF
--- a/rules/javascript/lang/logger_leak.yml
+++ b/rules/javascript/lang/logger_leak.yml
@@ -103,7 +103,14 @@ metadata:
       ```javascript
       logger.info(`Results: ${data}`) // unsafe
       ```
+    - **Do** log only non-sensitive data when using production-level loggers such as `info` or `warn`.
+      ```javascript
+      logger.info(`Results received: ${data.id}`) // safe, no sensitive data in info level
+      ```
     - **Do** use logging levels appropriately to control the verbosity of log output and minimize the risk of leaking sensitive information in production environments.
+      ```javascript
+      logger.debug(`Results: ${data}`) // safe when debug is disabled in production
+      ```
   cwe_id:
     - 532
   id: javascript_lang_logger_leak


### PR DESCRIPTION
Hi team! 👋

This small PR adds safe-code examples to the remediation section of the <code>javascript_lang_logger_leak</code> rule, as suggested in Bearer/bearer#1701.

**What changed:**
- Added a <b>safe</b> example showing how to log only non-sensitive fields at production levels (e.g. <code>info</code>).
- Added a <b>safe</b> example demonstrating the use of <code>debug</code> levels for detailed data, assuming debug is disabled in production.

I tried to keep the tone consistent with the existing documentation—hope it helps new users understand the fix at a glance. 😊

Happy to adjust the wording or examples if anything feels off. Just let me know!

Cheers,
Vincent

Closes Bearer/bearer#1701